### PR TITLE
메인 사이드바, 소개 페이지 추가

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
-import Main from './pages/Main';
 import GlobalStyles from './styles/GlobalStyles';
 import { theme } from './styles/theme';
+import Introduction from './pages/Introduction';
+import Main from './pages/Main';
 
 const App = (): JSX.Element => {
   return (
     <ThemeProvider theme={theme}>
       <BrowserRouter>
         <Switch>
+          <Route exact path="/" component={Introduction} />
           <Route path="/main" component={Main} />
           <Redirect from="*" to="/" />
         </Switch>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
-import Login from './pages/Login';
 import Main from './pages/Main';
 import GlobalStyles from './styles/GlobalStyles';
 import { theme } from './styles/theme';
@@ -11,7 +10,6 @@ const App = (): JSX.Element => {
     <ThemeProvider theme={theme}>
       <BrowserRouter>
         <Switch>
-          <Route path="/login" component={Login} />
           <Route path="/main" component={Main} />
           <Redirect from="*" to="/" />
         </Switch>

--- a/client/src/components/LoginModal.tsx
+++ b/client/src/components/LoginModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import Modal from '../../components/Modal';
-import JoinForm from '../../components/JoinForm';
-import LoginForm from '../../components/LoginForm';
+import Modal from './Modal';
+import JoinForm from './JoinForm';
+import LoginForm from './LoginForm';
 
 interface LoginProps {
   modal: boolean;
@@ -10,9 +10,7 @@ interface LoginProps {
 
 const Login: React.FC<LoginProps> = ({ modal, setModal }) => {
   const [isLogin, setIsLogin] = useState(true);
-
   const onClickModalToggle = () => setIsLogin(!isLogin);
-
   return (
     <>
       {modal && (

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 export const ModalContainer = styled.div`
@@ -37,24 +37,20 @@ export const Title = styled.h4`
 
 interface ModalProps {
   title?: string;
+  setModal: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Modal: React.FC<ModalProps> = ({ children, title }) => {
-  const [modal, setModal] = useState(true);
+const Modal: React.FC<ModalProps> = ({ setModal, children, title }) => {
   const onClickModalBackground = () => setModal(false);
   return (
-    <>
-      {modal && (
-        <ModalContainer>
-          <ModalBackground onClick={onClickModalBackground}>
-            <ModalWrapper onClick={(e) => e.stopPropagation()}>
-              {title && <Title>{title}</Title>}
-              {children}
-            </ModalWrapper>
-          </ModalBackground>
-        </ModalContainer>
-      )}
-    </>
+    <ModalContainer>
+      <ModalBackground onClick={onClickModalBackground}>
+        <ModalWrapper onClick={(e) => e.stopPropagation()}>
+          {title && <Title>{title}</Title>}
+          {children}
+        </ModalWrapper>
+      </ModalBackground>
+    </ModalContainer>
   );
 };
 

--- a/client/src/components/SideBar.tsx
+++ b/client/src/components/SideBar.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import styled, { css } from 'styled-components';
+import Login from '../pages/Login';
+
+const SideBarContainer = styled.div`
+  padding: ${({ theme }) => theme.paddings.lg};
+  display: flex;
+  flex-direction: column;
+  width: 23vw;
+  height: 100%;
+  background-color: #21272e;
+`;
+
+const LoginBtn = styled.button`
+  ${({ theme }) => css`
+    border: 1px solid ${theme.colors.primary};
+    padding: ${theme.paddings.sm};
+    border-radius: ${theme.borderRadius.sm};
+    font-size: ${theme.fontSizes.lg};
+  `};
+  width: 100%;
+  text-align: center;
+`;
+
+const SideBar: React.FC = () => {
+  const [loginModal, setLoginModal] = useState(false);
+
+  const onClick = () => setLoginModal(!loginModal);
+  return (
+    <SideBarContainer>
+      <LoginBtn onClick={onClick}>로그인</LoginBtn>
+      {loginModal && <Login />}
+    </SideBarContainer>
+  );
+};
+
+export default SideBar;

--- a/client/src/components/SideBar.tsx
+++ b/client/src/components/SideBar.tsx
@@ -2,11 +2,14 @@ import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import LoginModal from './LoginModal';
 
+const SIDEBAR_MIN_WIDTH = '33rem';
+
 const SideBarContainer = styled.div`
   padding: ${({ theme }) => theme.paddings.lg};
   display: flex;
   flex-direction: column;
   width: 23vw;
+  min-width: ${SIDEBAR_MIN_WIDTH};
   height: 100%;
   background-color: #21272e;
 `;
@@ -20,6 +23,9 @@ const LoginBtn = styled.button`
   `};
   width: 100%;
   text-align: center;
+  :hover {
+    background-color: ${({ theme }) => theme.colors.primary};
+  }
 `;
 
 const SideBar: React.FC = () => {

--- a/client/src/components/SideBar.tsx
+++ b/client/src/components/SideBar.tsx
@@ -29,7 +29,7 @@ const SideBar: React.FC = () => {
   return (
     <SideBarContainer>
       <LoginBtn onClick={onClick}>로그인</LoginBtn>
-      {loginModal && <Login />}
+      {loginModal && <Login modal={loginModal} setModal={setLoginModal} />}
     </SideBarContainer>
   );
 };

--- a/client/src/components/SideBar.tsx
+++ b/client/src/components/SideBar.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
-import Login from '../pages/Login';
+import LoginModal from './LoginModal';
 
 const SideBarContainer = styled.div`
   padding: ${({ theme }) => theme.paddings.lg};
@@ -29,7 +29,7 @@ const SideBar: React.FC = () => {
   return (
     <SideBarContainer>
       <LoginBtn onClick={onClick}>로그인</LoginBtn>
-      {loginModal && <Login modal={loginModal} setModal={setLoginModal} />}
+      {loginModal && <LoginModal modal={loginModal} setModal={setLoginModal} />}
     </SideBarContainer>
   );
 };

--- a/client/src/pages/Introduction/Introduction.tsx
+++ b/client/src/pages/Introduction/Introduction.tsx
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+
+const IntroContainer = styled.div`
+  ${({ theme }) => theme.flexCenter};
+  flex-direction: column;
+  padding: ${({ theme }) => theme.paddings.base};
+`;
+
+const IntroTitle = styled.h1`
+  font-size: ${({ theme }) => theme.fontSizes.title};
+  margin-bottom: ${({ theme }) => theme.margins.lg};
+`;
+
+const TitleText = styled.span`
+  color: ${(props) => props.color};
+`;
+
+const MainBtn = styled.button`
+  width: 30rem;
+  height: 20rem;
+  border: 1px solid ${({ theme }) => theme.colors.secondary};
+  border-radius: ${({ theme }) => theme.borderRadius.lg};
+  font-size: ${({ theme }) => theme.fontSizes.lg};
+  :hover {
+    background-color: ${({ theme }) => theme.colors.secondary};
+    color: ${({ theme }) => theme.colors.black};
+  }
+`;
+
+const Introduction = (props: {
+  history: {
+    push(url: string): void;
+  };
+}): JSX.Element => {
+  console.log(props);
+  const onClick = () => props.history.push('/main');
+  return (
+    <IntroContainer>
+      <IntroTitle>
+        <TitleText color={'red'}>타</TitleText>
+        <TitleText color={'orange'}>닥</TitleText>
+        <TitleText color={'red'}>타</TitleText>
+        <TitleText color={'yellow'}>닥</TitleText> 🔥
+      </IntroTitle>
+      <MainBtn onClick={onClick}>메인으로 가기</MainBtn>
+    </IntroContainer>
+  );
+};
+
+export default Introduction;

--- a/client/src/pages/Introduction/index.ts
+++ b/client/src/pages/Introduction/index.ts
@@ -1,0 +1,3 @@
+import Introduction from './Introduction';
+
+export default Introduction;

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -3,19 +3,28 @@ import Modal from '../../components/Modal';
 import JoinForm from '../../components/JoinForm';
 import LoginForm from '../../components/LoginForm';
 
-const Login: React.FC = () => {
+interface LoginProps {
+  modal: boolean;
+  setModal: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const Login: React.FC<LoginProps> = ({ modal, setModal }) => {
   const [isLogin, setIsLogin] = useState(true);
 
   const onClickModalToggle = () => setIsLogin(!isLogin);
 
   return (
-    <Modal title={isLogin ? '로그인' : '회원가입'}>
-      {isLogin ? (
-        <LoginForm onClickModalToggle={onClickModalToggle} />
-      ) : (
-        <JoinForm onClickModalToggle={onClickModalToggle} />
+    <>
+      {modal && (
+        <Modal title={isLogin ? '로그인' : '회원가입'} setModal={setModal}>
+          {isLogin ? (
+            <LoginForm onClickModalToggle={onClickModalToggle} />
+          ) : (
+            <JoinForm onClickModalToggle={onClickModalToggle} />
+          )}
+        </Modal>
       )}
-    </Modal>
+    </>
   );
 };
 

--- a/client/src/pages/Login/index.ts
+++ b/client/src/pages/Login/index.ts
@@ -1,3 +1,0 @@
-import Login from './Login';
-
-export default Login;

--- a/client/src/pages/Main/Main.tsx
+++ b/client/src/pages/Main/Main.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { MainContainer, MainTitle, RoomListGrid } from './style';
+import { MainWrapper, MainContainer, MainTitle, RoomListGrid } from './style';
 import VideoContainer from './VideoContainer';
 import RoomBox from '../../components/RoomBox';
+import SideBar from '../../components/SideBar';
 
 const roomInfos = [
   {
@@ -14,26 +15,29 @@ const Main = (): JSX.Element => {
   const [inCall, setInCall] = useState(false);
   const [channelName, setChannelName] = useState('');
   return (
-    <MainContainer>
-      {inCall ? (
-        <VideoContainer setInCall={setInCall} channelName={channelName} />
-      ) : (
-        <>
-          <MainTitle className="heading">채널 목록</MainTitle>
-          <RoomListGrid>
-            {roomInfos &&
-              roomInfos.map((roomInfo) => (
-                <RoomBox
-                  key={roomInfo.channelName}
-                  setInCall={setInCall}
-                  setChannelName={setChannelName}
-                  roomInfo={roomInfo}
-                />
-              ))}
-          </RoomListGrid>
-        </>
-      )}
-    </MainContainer>
+    <MainWrapper>
+      <SideBar />
+      <MainContainer>
+        {inCall ? (
+          <VideoContainer setInCall={setInCall} channelName={channelName} />
+        ) : (
+          <>
+            <MainTitle className="heading">채널 목록</MainTitle>
+            <RoomListGrid>
+              {roomInfos &&
+                roomInfos.map((roomInfo) => (
+                  <RoomBox
+                    key={roomInfo.channelName}
+                    setInCall={setInCall}
+                    setChannelName={setChannelName}
+                    roomInfo={roomInfo}
+                  />
+                ))}
+            </RoomListGrid>
+          </>
+        )}
+      </MainContainer>
+    </MainWrapper>
   );
 };
 

--- a/client/src/pages/Main/style.ts
+++ b/client/src/pages/Main/style.ts
@@ -1,7 +1,14 @@
 import styled from 'styled-components';
 
+export const MainWrapper = styled.div`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+`;
+
 export const MainContainer = styled.div`
   padding: ${({ theme }) => theme.paddings.lg};
+  height: 100%;
 `;
 
 export const MainTitle = styled.h1`


### PR DESCRIPTION
## 개요
메인 사이드바와 소개 페이지를 추가하고 몇가지 리팩토링을 진행했습니다.


## 작업 사항
- 메인 사이드바를 메인페이지에 추가했습니다.
- 모달 상태를 모달 상위 컴포넌트에서 관리하여 모달을 on/off하도록 수정했습니다.
- 테스를 위한 로그인 페이지를 삭제하고 로그인 모달로 변경했습니다.
- 소개페이지를 추가하고, 메인페이지로 이동하는 버튼을 추가했습니다.


## 🧐고민고민
내일이 구현 후 첫 데모인데 잘 되었으면 좋겠네요!.
한별님과 논의 후 모달 상태를 모달 상위에서 관리하도록 수정했는데, 다른분들의 의견도 궁급합니다.
- 현재 모달을 상위 모달인 로그인 모달에서 사용하고 있고, 로그인 모달을 사이드바에서 사용하고 있어서
- 모달에 있는 상태를 사이드바에서 관리하도록 변경했습니다.