### PR TITLE
Room 관련 API & Swagger 설정 & Common Exception & Builder 패턴 적용

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/jwt": "^8.0.0",
         "@nestjs/passport": "^8.0.1",
         "@nestjs/platform-express": "^8.0.0",
+        "@nestjs/swagger": "^5.1.4",
         "@nestjs/typeorm": "^8.0.2",
         "@types/bcrypt": "^5.0.0",
         "@types/uuid": "^8.3.1",
@@ -31,6 +32,7 @@
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
+        "swagger-ui-express": "^4.1.6",
         "typeorm": "^0.2.38",
         "typeorm-naming-strategies": "^2.0.0"
       },
@@ -1582,6 +1584,17 @@
         "@nestjs/common": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.0.0.tgz",
+      "integrity": "sha512-26AW5jHadLXtvHs+M+Agd9KZ92dDlBrmD0rORlBlvn2KvsWs4JRaKl2mUsrW7YsdZeAu3Hc4ukqyYyDdyCmMWQ==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.8 || ^8.0.0",
+        "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0",
+        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+        "reflect-metadata": "^0.1.12"
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-8.0.1.tgz",
@@ -1625,6 +1638,31 @@
       },
       "peerDependencies": {
         "typescript": "^3.4.5 || ^4.3.5"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-5.1.4.tgz",
+      "integrity": "sha512-hwVo57Nhw+TyS3xXa8pQAMVOXQAoXBszJbnUAqLcKlVtQ8jqmSRKPTApefXSf/XDoG5LekRYi9Re2SOt1T2WlA==",
+      "dependencies": {
+        "@nestjs/mapped-types": "1.0.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0",
+        "@nestjs/core": "^8.0.0",
+        "fastify-swagger": "*",
+        "reflect-metadata": "^0.1.12",
+        "swagger-ui-express": "*"
+      },
+      "peerDependenciesMeta": {
+        "fastify-swagger": {
+          "optional": true
+        },
+        "swagger-ui-express": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -6796,8 +6834,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -8660,6 +8697,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "3.52.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.52.5.tgz",
+      "integrity": "sha512-8z18eX8G/jbTXYzyNIaobrnD7PSN7yU/YkSasMmajrXtw0FGS64XjrKn5v37d36qmU3o1xLeuYnktshRr7uIFw=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
+      "integrity": "sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==",
+      "dependencies": {
+        "swagger-ui-dist": "^3.18.1"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0"
       }
     },
     "node_modules/symbol-observable": {
@@ -11138,6 +11194,12 @@
         "jsonwebtoken": "8.5.1"
       }
     },
+    "@nestjs/mapped-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.0.0.tgz",
+      "integrity": "sha512-26AW5jHadLXtvHs+M+Agd9KZ92dDlBrmD0rORlBlvn2KvsWs4JRaKl2mUsrW7YsdZeAu3Hc4ukqyYyDdyCmMWQ==",
+      "requires": {}
+    },
     "@nestjs/passport": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-8.0.1.tgz",
@@ -11167,6 +11229,16 @@
         "fs-extra": "10.0.0",
         "jsonc-parser": "3.0.0",
         "pluralize": "8.0.0"
+      }
+    },
+    "@nestjs/swagger": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-5.1.4.tgz",
+      "integrity": "sha512-hwVo57Nhw+TyS3xXa8pQAMVOXQAoXBszJbnUAqLcKlVtQ8jqmSRKPTApefXSf/XDoG5LekRYi9Re2SOt1T2WlA==",
+      "requires": {
+        "@nestjs/mapped-types": "1.0.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0"
       }
     },
     "@nestjs/testing": {
@@ -15172,8 +15244,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -16599,6 +16670,19 @@
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "3.52.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.52.5.tgz",
+      "integrity": "sha512-8z18eX8G/jbTXYzyNIaobrnD7PSN7yU/YkSasMmajrXtw0FGS64XjrKn5v37d36qmU3o1xLeuYnktshRr7uIFw=="
+    },
+    "swagger-ui-express": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
+      "integrity": "sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
       }
     },
     "symbol-observable": {

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
     "@nestjs/jwt": "^8.0.0",
     "@nestjs/passport": "^8.0.1",
     "@nestjs/platform-express": "^8.0.0",
+    "@nestjs/swagger": "^5.1.4",
     "@nestjs/typeorm": "^8.0.2",
     "@types/bcrypt": "^5.0.0",
     "@types/uuid": "^8.3.1",
@@ -44,6 +45,7 @@
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
+    "swagger-ui-express": "^4.1.6",
     "typeorm": "^0.2.38",
     "typeorm-naming-strategies": "^2.0.0"
   },

--- a/server/src/builder/builder.ts
+++ b/server/src/builder/builder.ts
@@ -1,0 +1,12 @@
+interface ConstructorType<T> {
+  new (): T;
+}
+export class BuilderCommon<T> {
+  public object: T;
+  constructor(ctor: ConstructorType<T>) {
+    this.object = new ctor();
+  }
+  build(): T {
+    return this.object;
+  }
+}

--- a/server/src/builder/index.ts
+++ b/server/src/builder/index.ts
@@ -1,0 +1,4 @@
+export { RoomBuilder } from './room.builder';
+export { UserBuilder } from './user.builder';
+
+export { BuilderCommon } from './builder';

--- a/server/src/builder/room.builder.ts
+++ b/server/src/builder/room.builder.ts
@@ -1,0 +1,54 @@
+import { BuilderCommon } from './builder';
+import { User } from '../domain/user/user.entity';
+import { Room, RoomType } from '../domain/room/room.entity';
+
+export class RoomBuilder extends BuilderCommon<Room> {
+  constructor() {
+    super(Room);
+  }
+
+  setUUID(uuid: string): RoomBuilder {
+    this.object.uuid = uuid;
+    return this;
+  }
+
+  setAgoraAppID(agoraAppId: string): RoomBuilder {
+    this.object.agoraAppId = agoraAppId;
+    return this;
+  }
+
+  setAgoraToken(agoraToken: string): RoomBuilder {
+    this.object.agoraToken = agoraToken;
+    return this;
+  }
+
+  setTitle(title: string): RoomBuilder {
+    this.object.title = title;
+    return this;
+  }
+
+  setDescription(description: string): RoomBuilder {
+    this.object.description = description;
+    return this;
+  }
+
+  setMaxHeadcount(maxHeadcount: number): RoomBuilder {
+    this.object.maxHeadcount = maxHeadcount;
+    return this;
+  }
+
+  setNowHeadcount(nowHeadcount: number): RoomBuilder {
+    this.object.nowHeadcount = nowHeadcount;
+    return this;
+  }
+
+  setOwner(owner: User): RoomBuilder {
+    this.object.owner = owner;
+    return this;
+  }
+
+  setRoomType(roomType: RoomType): RoomBuilder {
+    this.object.roomType = roomType;
+    return this;
+  }
+}

--- a/server/src/builder/user.builder.ts
+++ b/server/src/builder/user.builder.ts
@@ -1,0 +1,56 @@
+import { BuilderCommon } from './builder';
+import { User } from '../domain/user/user.entity';
+import { DevField } from '../domain/user/dev-field.entity';
+import { Follow } from '../domain/user/follow.entity';
+import { History } from '../domain/user/history.entity';
+
+export class UserBuilder extends BuilderCommon<User> {
+  constructor() {
+    super(User);
+  }
+
+  setNickName(nickName: string): UserBuilder {
+    this.object.nickName = nickName;
+    return this;
+  }
+
+  setEmail(email: string): UserBuilder {
+    this.object.email = email;
+    return this;
+  }
+
+  setPassword(password: string): UserBuilder {
+    this.object.password = password;
+    return this;
+  }
+
+  setImageURL(imageUrl: string): UserBuilder {
+    this.object.imageUrl = imageUrl;
+    return this;
+  }
+
+  setIntroduction(text: string): UserBuilder {
+    this.object.introduction = text;
+    return this;
+  }
+
+  setIsSocial(isSocial: boolean): UserBuilder {
+    this.object.isSocial = isSocial;
+    return this;
+  }
+
+  setDevField(devField: DevField): UserBuilder {
+    this.object.devField = devField;
+    return this;
+  }
+
+  setFollows(follows: Follow[]): UserBuilder {
+    this.object.follows = follows;
+    return this;
+  }
+
+  setHistorys(historys: History[]): UserBuilder {
+    this.object.historys = historys;
+    return this;
+  }
+}

--- a/server/src/config/swagger.config.ts
+++ b/server/src/config/swagger.config.ts
@@ -1,0 +1,14 @@
+import { INestApplication } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+
+export function SwaggerConfig(app: INestApplication): void {
+  const URL = 'api-docs';
+  const option = new DocumentBuilder()
+    .setTitle('타닥타닥 API 문서')
+    .setDescription('타닥타닥의 API 문서입니다.')
+    .setContact('타닥타닥 개발팀', 'https://tadaktadak.com', null)
+    .setVersion('1.0.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, option);
+  SwaggerModule.setup(URL, app, document);
+}

--- a/server/src/config/typeorm.config.ts
+++ b/server/src/config/typeorm.config.ts
@@ -11,4 +11,5 @@ export const TypeOrmConfig: TypeOrmModuleOptions = {
   entities: [__dirname + '/../**/*.entity.{js,ts}'],
   synchronize: false,
   namingStrategy: new SnakeNamingStrategy(),
+  logging: true,
 };

--- a/server/src/domain/BaseTimeEntity.ts
+++ b/server/src/domain/BaseTimeEntity.ts
@@ -1,11 +1,5 @@
-import {
-  CreateDateColumn,
-  Generated,
-  PrimaryColumn,
-  UpdateDateColumn,
-} from 'typeorm';
+import { CreateDateColumn, Generated, PrimaryColumn, UpdateDateColumn } from 'typeorm';
 import { BigintValueTransformer } from '../transformer/BigintValueTransformer';
-
 
 export abstract class BaseTimeEntity {
   @Generated('increment')

--- a/server/src/domain/auth/service/auth.service.ts
+++ b/server/src/domain/auth/service/auth.service.ts
@@ -7,6 +7,7 @@ import { AuthRepository } from '../auth.repository';
 import { LoginRequestDto } from '../dto/login-request.dto';
 import { LoginResponseDto } from '../dto/login-response.dto';
 import { JoinRequestDto } from '../dto/join-request.dto';
+import { UserBuilder } from '../../../builder';
 
 @Injectable()
 export class AuthService {
@@ -25,13 +26,17 @@ export class AuthService {
   }
 
   async join(joinRequestDto: JoinRequestDto) {
+    const { nickname, email, password } = joinRequestDto;
+    const baseImageURL = '디폴트 이미지 주소 자리';
     const isExistUser = await this.authRepository.exists(joinRequestDto);
     if (isExistUser) throw new BadRequestException();
-    const user: User = await this.authRepository.create();
-    user.nickName = joinRequestDto.nickname;
-    user.email = joinRequestDto.email;
-    user.password = Bcrypt.hash(joinRequestDto.password);
-    user.imageUrl = '디폴트 이미지 주소 자리';
+    if (isExistUser) throw UserException.userIsExist();
+    const user: User = new UserBuilder()
+      .setNickName(nickname)
+      .setEmail(email)
+      .setPassword(Bcrypt.hash(password))
+      .setImageURL(baseImageURL)
+      .build();
     await this.authRepository.save(user);
     return true;
   }

--- a/server/src/domain/auth/service/auth.service.ts
+++ b/server/src/domain/auth/service/auth.service.ts
@@ -8,6 +8,7 @@ import { LoginRequestDto } from '../dto/login-request.dto';
 import { LoginResponseDto } from '../dto/login-response.dto';
 import { JoinRequestDto } from '../dto/join-request.dto';
 import { UserBuilder } from '../../../builder';
+import { UserException } from '../../../exception/user.exception';
 
 @Injectable()
 export class AuthService {
@@ -19,7 +20,8 @@ export class AuthService {
 
   async login(loginRequestDto: LoginRequestDto) {
     const user: User = await this.authRepository.findUserByEmail(loginRequestDto.email);
-    if (!user || !Bcrypt.compare(loginRequestDto.password, user.password)) throw new UnauthorizedException();
+    if (!user || !Bcrypt.compare(loginRequestDto.password, user.password))
+      throw UserException.userLoginInfoNotCorrect();
     const token = this.jwtService.sign({ email: loginRequestDto.email });
     const userInfo: LoginResponseDto = new LoginResponseDto(user);
     return { token, userInfo };
@@ -29,7 +31,6 @@ export class AuthService {
     const { nickname, email, password } = joinRequestDto;
     const baseImageURL = '디폴트 이미지 주소 자리';
     const isExistUser = await this.authRepository.exists(joinRequestDto);
-    if (isExistUser) throw new BadRequestException();
     if (isExistUser) throw UserException.userIsExist();
     const user: User = new UserBuilder()
       .setNickName(nickname)

--- a/server/src/domain/room/controller/room.controller.ts
+++ b/server/src/domain/room/controller/room.controller.ts
@@ -1,36 +1,17 @@
-import { Body, Controller, Delete, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Query, Req, UseGuards } from '@nestjs/common';
 import { RoomService } from '../service/room.service';
-import { Room, RoomType } from '../room.entity';
 import { Pagination } from 'src/paginate';
 import { CreateRoomRequestDto } from '../dto/create-room-request.dto';
 import { JwtAuthGuard } from '../../auth/guard/jwt-auth-guard';
 import { CreateRoomResponseDto } from '../dto/create-room-response.dto';
+import { Request } from 'express';
+import { Type } from 'class-transformer';
 
 @Controller('room')
 export class RoomController {
-  constructor(private readonly roomService: RoomService) {
-  }
 
-  @Get('tadak')
-  async getBasicListAll(
-    @Query('search') search: string,
-    @Query('take') take: number,
-    @Query('page') page: number,
-  ): Promise<Pagination<Room>> {
-    return await this.roomService.getRoomListAll({ search, take, page }, RoomType.TadakTadak);
-  }
-
-  @Get('camp')
-  async getCampListAll(
-    @Query('search') search: string,
-    @Query('take') take: number,
-    @Query('page') page: number,
-  ): Promise<Pagination<Room>> {
-    return await this.roomService.getRoomListAll({ search, take, page }, RoomType.CampFire);
-  }
-
-  @Get('live')
-  async getLiveListAll(
+  async getRoomListByType(
+    @Query('type') type: RoomType,
     @Query('search') search: string,
     @Query('take') take: number,
     @Query('page') page: number,

--- a/server/src/domain/room/controller/room.controller.ts
+++ b/server/src/domain/room/controller/room.controller.ts
@@ -1,16 +1,26 @@
 import { Body, Controller, Delete, Get, Param, Post, Query, Req, UseGuards } from '@nestjs/common';
 import { RoomService } from '../service/room.service';
+import { Room, RoomType, roomTypeToArray } from '../room.entity';
 import { Pagination } from 'src/paginate';
 import { CreateRoomRequestDto } from '../dto/create-room-request.dto';
 import { JwtAuthGuard } from '../../auth/guard/jwt-auth-guard';
 import { CreateRoomResponseDto } from '../dto/create-room-response.dto';
 import { Request } from 'express';
+import { ApiExtraModels, ApiOkResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
+import { RoomAPIDocs } from '../room.docs';
 
+@ApiTags('Room API / 방 API')
 @Controller('room')
 export class RoomController {
   constructor(private readonly roomService: RoomService) {}
 
+  @Get()
+  @ApiOperation(RoomAPIDocs.getRoomListByTypeOperation())
+  @ApiQuery(RoomAPIDocs.getRoomListByTypeQueryType())
+  @ApiQuery(RoomAPIDocs.getRoomListByTypeQuerySearch())
+  @ApiQuery(RoomAPIDocs.getRoomListByTypeQueryTake())
+  @ApiQuery(RoomAPIDocs.getRoomListByTypeQueryPage())
   async getRoomListByType(
     @Query('type') type: RoomType,
     @Query('search') search: string,

--- a/server/src/domain/room/controller/room.controller.ts
+++ b/server/src/domain/room/controller/room.controller.ts
@@ -32,5 +32,11 @@ export class RoomController {
   async getRoomByUUID(@Param('uuid') uuid): Promise<{ result: Room }> {
     return { result: await this.roomService.getRoomByUUID(uuid) };
   }
+
+  @Delete(':uuid')
+  @UseGuards(JwtAuthGuard)
+  async deleteRoom(@Req() req: Request, @Param('uuid') uuid): Promise<{ result: boolean }> {
+    const userEmail = req.user['email'];
+    return { result: await this.roomService.deleteRoom(userEmail, uuid) };
   }
 }

--- a/server/src/domain/room/controller/room.controller.ts
+++ b/server/src/domain/room/controller/room.controller.ts
@@ -34,8 +34,8 @@ export class RoomController {
     @Query('search') search: string,
     @Query('take') take: number,
     @Query('page') page: number,
-  ): Promise<Pagination<Room>> {
-    return await this.roomService.getRoomListAll({ search, take, page }, RoomType.CodingLive);
+  ): Promise<{ result: Pagination<Room> }> {
+    return { result: await this.roomService.getRoomListAll({ search, take, page }, type) };
   }
 
   @Post()

--- a/server/src/domain/room/controller/room.controller.ts
+++ b/server/src/domain/room/controller/room.controller.ts
@@ -9,6 +9,7 @@ import { Type } from 'class-transformer';
 
 @Controller('room')
 export class RoomController {
+  constructor(private readonly roomService: RoomService) {}
 
   async getRoomListByType(
     @Query('type') type: RoomType,
@@ -25,8 +26,11 @@ export class RoomController {
     return { result: await this.roomService.createRoom(createRoomRequestDto) };
   }
 
-  @Delete(':roomId')
-  deleteRoom(@Param('roomId') id): number {
-    return 0;
+  @Get(':uuid')
+  @ApiOperation({ summary: 'UUID로 방 조회', description: '방의 고유 UUID로 정보를 조회합니다.' })
+  @ApiParam(RoomAPIDocs.getRoomByUUIDParamUUID())
+  async getRoomByUUID(@Param('uuid') uuid): Promise<{ result: Room }> {
+    return { result: await this.roomService.getRoomByUUID(uuid) };
+  }
   }
 }

--- a/server/src/domain/room/dto/create-room-response.dto.ts
+++ b/server/src/domain/room/dto/create-room-response.dto.ts
@@ -1,25 +1,10 @@
 import { Room } from '../room.entity';
 
 export class CreateRoomResponseDto {
-  appId: string;
-  token: string;
-  uuid: string;
-  ownerId: number;
-  title: string;
-  description: string;
-  nowHeadcount: number;
-  maxHeadcount: number;
-  roomType: string;
+  private room: Room;
 
-  constructor(room: Room, appID: string, token: string, uuid: string) {
-    this.appId = appID;
-    this.token = token;
-    this.uuid = uuid;
-    this.ownerId = room.owner.id;
-    this.title = room.title;
-    this.description = room.description;
-    this.nowHeadcount = room.nowHeadcount;
-    this.maxHeadcount = room.maxHeadcount;
-    this.roomType = room.roomType;
+  constructor(room: Room) {
+    //Todo: Owner(User) password hide
+    this.room = room;
   }
 }

--- a/server/src/domain/room/repository/room.repository.ts
+++ b/server/src/domain/room/repository/room.repository.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, Like, Repository } from 'typeorm';
+import { DeleteResult, EntityRepository, Like, Repository } from 'typeorm';
 import { Room, RoomType } from '../room.entity';
 import { PaginationOptions } from '../../../paginate';
 
@@ -8,7 +8,7 @@ export class RoomRepository extends Repository<Room> {
     const { search, take, page } = options;
     return this.findAndCount({
       where: { title: Like('%' + search + '%'), roomType: roomType },
-      order: { title: 'DESC' },
+      order: { nowHeadcount: 'DESC' },
       take: take,
       skip: take * (page - 1),
     });

--- a/server/src/domain/room/repository/room.repository.ts
+++ b/server/src/domain/room/repository/room.repository.ts
@@ -17,4 +17,23 @@ export class RoomRepository extends Repository<Room> {
   async createRoom(room: Room) {
     return this.save(room);
   }
+
+  async findRoomByUUID(uuid: string): Promise<Room> {
+    return this.findOne({ where: { uuid } });
+  }
+
+  async findRoomByUserEmail(email: string): Promise<Room> {
+    return this.createQueryBuilder('room')
+      .leftJoinAndSelect('room.owner', 'user')
+      .where('user.email = :email', { email: email })
+      .getOne();
+  }
+
+  async findRoomByUserEmailAndUUID(email: string, uuid: string): Promise<Room> {
+    return this.createQueryBuilder('room')
+      .leftJoinAndSelect('room.owner', 'user')
+      .where('user.email = :email', { email: email })
+      .where('uuid = :uuid', { uuid: uuid })
+      .getOne();
+  }
 }

--- a/server/src/domain/room/repository/room.repository.ts
+++ b/server/src/domain/room/repository/room.repository.ts
@@ -36,4 +36,8 @@ export class RoomRepository extends Repository<Room> {
       .where('uuid = :uuid', { uuid: uuid })
       .getOne();
   }
+
+  async deleteRoomByRoomID(roomID: number): Promise<DeleteResult> {
+    return this.delete({ id: roomID });
+  }
 }

--- a/server/src/domain/room/room.docs.ts
+++ b/server/src/domain/room/room.docs.ts
@@ -1,0 +1,54 @@
+import { ApiParamOptions, ApiQueryOptions } from '@nestjs/swagger';
+import { RoomType, roomTypeToArray } from './room.entity';
+
+export class RoomAPIDocs {
+  static getRoomListByTypeOperation(): { summary: string; description: string } {
+    return { summary: '방 검색 API', description: '키워드, 페이지 별로 방을 검색합니다.' };
+  }
+
+  static getRoomListByTypeQueryType(): ApiQueryOptions {
+    return {
+      name: 'type',
+      example: RoomType.TadakTadak,
+      required: true,
+      description: `검색할 방의 타입입니다.\n
+      ${roomTypeToArray()}가 존재합니다.`,
+    };
+  }
+
+  static getRoomListByTypeQuerySearch(): ApiQueryOptions {
+    return {
+      name: 'search',
+      example: '재밌는',
+      required: true,
+      description: '검색할 방의 제목입니다.',
+    };
+  }
+
+  static getRoomListByTypeQueryTake(): ApiQueryOptions {
+    return {
+      name: 'take',
+      example: 5,
+      required: true,
+      description: '결과를 몇개의 단위로 가져올지 입니다.',
+    };
+  }
+
+  static getRoomListByTypeQueryPage(): ApiQueryOptions {
+    return {
+      name: 'page',
+      example: 1,
+      required: true,
+      description: '몇 번째 페이지의 결과를 가져올지 입니다.',
+    };
+  }
+
+  static getRoomByUUIDParamUUID(): ApiParamOptions {
+    return {
+      name: 'uuid',
+      example: 'c5ddd9c2-02c6-4cdf-a1d1-077e00103f91',
+      required: true,
+      description: '방의 UUID 입니다.',
+    };
+  }
+}

--- a/server/src/domain/room/room.entity.ts
+++ b/server/src/domain/room/room.entity.ts
@@ -1,7 +1,6 @@
 import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { User } from 'src/domain/user/user.entity';
 import { BaseTimeEntity } from '../BaseTimeEntity';
-import { CreateRoomRequestDto } from './dto/create-room-request.dto';
 
 export enum RoomType {
   TadakTadak = '타닥타닥',
@@ -9,16 +8,12 @@ export enum RoomType {
   CodingLive = '코딩라이브',
 }
 
+export function roomTypeToArray() {
+  return Object.keys(RoomType).map((key) => RoomType[key]);
+}
+
 @Entity()
 export class Room extends BaseTimeEntity {
-  constructor(title: string, description: string, maxHeadcount: number, roomType: RoomType) {
-    super();
-    this.title = title;
-    this.description = description;
-    this.maxHeadcount = maxHeadcount;
-    this.roomType = roomType;
-  }
-
   @PrimaryGeneratedColumn()
   id: number;
 
@@ -49,29 +44,4 @@ export class Room extends BaseTimeEntity {
 
   @Column('varchar')
   roomType: RoomType;
-
-  static builder(createRoomRequestDto: CreateRoomRequestDto): Room {
-    const { title, description, maxHeadcount, roomType } = createRoomRequestDto;
-    return new Room(title, description, maxHeadcount, roomType);
-  }
-
-  setAgoraAppId(appId: string) {
-    this.agoraAppId = appId;
-  }
-
-  setAgoraToken(token: string) {
-    this.agoraToken = token;
-  }
-
-  setUUID(uuid: string) {
-    this.uuid = uuid;
-  }
-
-  setOwner(user: User) {
-    this.owner = user;
-  }
-
-  setNowHeadcount(cnt: number) {
-    this.nowHeadcount = cnt;
-  }
 }

--- a/server/src/domain/room/service/room.service.ts
+++ b/server/src/domain/room/service/room.service.ts
@@ -21,6 +21,9 @@ export class RoomService {
     @InjectRepository(UserRepository)
     private readonly userRepository: UserRepository,
   ) {}
+
+  async getRoomByUUID(uuid: string): Promise<Room> {
+    return await this.roomRepository.findRoomByUUID(uuid);
   }
 
   async getRoomListAll(options: PaginationOptions, roomType: RoomType): Promise<Pagination<Room>> {

--- a/server/src/domain/room/service/room.service.ts
+++ b/server/src/domain/room/service/room.service.ts
@@ -20,7 +20,7 @@ export class RoomService {
     private readonly roomRepository: RoomRepository,
     @InjectRepository(UserRepository)
     private readonly userRepository: UserRepository,
-  ) {
+  ) {}
   }
 
   async getRoomListAll(options: PaginationOptions, roomType: RoomType): Promise<Pagination<Room>> {
@@ -32,10 +32,10 @@ export class RoomService {
   }
 
   async createRoom(createRoomRequestDto: CreateRoomRequestDto): Promise<CreateRoomResponseDto> {
-    const { userId } = createRoomRequestDto;
+    const { userId, title, description, maxHeadcount, roomType } = createRoomRequestDto;
     const uuid = uuidv4();
-    const appID = process.env.AGORA_APP_ID;
-    const token = this.createTokenWithChannel(userId, appID, uuid);
+    const agoraAppID = process.env.AGORA_APP_ID;
+    const agoraToken = this.createTokenWithChannel(userId, agoraAppID, uuid);
     const user = await this.userRepository.findUserById(userId);
     if (!user) throw UserException.userNotFound();
     const existRoom = await this.roomRepository.findRoomByUserEmail(user.email);

--- a/server/src/domain/room/service/room.service.ts
+++ b/server/src/domain/room/service/room.service.ts
@@ -39,12 +39,17 @@ export class RoomService {
         message: '사용자를 찾을 수 없습니다.',
       });
     }
-    const newRoom = Room.builder(createRoomRequestDto);
-    newRoom.setUUID(uuidv4().toString());
-    newRoom.setAgoraAppId(appID);
-    newRoom.setAgoraToken(token);
-    newRoom.setOwner(user);
-    newRoom.setNowHeadcount(1);
+    const newRoom = new RoomBuilder()
+      .setTitle(title)
+      .setDescription(description)
+      .setNowHeadcount(1)
+      .setMaxHeadcount(maxHeadcount)
+      .setRoomType(roomType)
+      .setUUID(uuid)
+      .setAgoraAppID(agoraAppID)
+      .setAgoraToken(agoraToken)
+      .setOwner(user)
+      .build();
     const result = await this.roomRepository.createRoom(newRoom);
     if (!result) {
       throw new InternalServerErrorException({

--- a/server/src/domain/user/repository/user.repository.ts
+++ b/server/src/domain/user/repository/user.repository.ts
@@ -4,6 +4,10 @@ import { User } from '../user.entity';
 @EntityRepository(User)
 export class UserRepository extends Repository<User> {
   async findUserById(userId: number): Promise<User> {
-    return this.findOneOrFail({ where: { id: userId } });
+    return this.findOne({ where: { id: userId } });
+  }
+
+  async findUserByUserEmail(email: string): Promise<User> {
+    return this.findOne({ where: { email: email } });
   }
 }

--- a/server/src/exception/room.exception.ts
+++ b/server/src/exception/room.exception.ts
@@ -1,0 +1,37 @@
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+
+export class RoomException {
+  static roomNotFound(): HttpException {
+    return new NotFoundException({
+      statusCode: HttpStatus.NOT_FOUND,
+      message: '해당되는 방을 찾을 수 없습니다.',
+    });
+  }
+
+  static roomExistError(): HttpException {
+    return new BadRequestException({
+      statusCode: HttpStatus.BAD_REQUEST,
+      message: '현재 계정으로 생성된 방이 존재합니다.',
+    });
+  }
+
+  static roomCreateError(): HttpException {
+    return new InternalServerErrorException({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: '방 생성중 오류가 발생했습니다.',
+    });
+  }
+
+  static roomDeleteError(): HttpException {
+    return new InternalServerErrorException({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: '방 삭제중 오류가 발생했습니다.',
+    });
+  }
+}

--- a/server/src/exception/user.exception.ts
+++ b/server/src/exception/user.exception.ts
@@ -1,0 +1,30 @@
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+export class UserException {
+  static userNotFound(): HttpException {
+    return new NotFoundException({
+      statusCode: HttpStatus.NOT_FOUND,
+      message: '사용자를 찾을 수 없습니다.',
+    });
+  }
+
+  static userLoginInfoNotCorrect(): HttpException {
+    return new UnauthorizedException({
+      statusCode: HttpStatus.UNAUTHORIZED,
+      message: '입력하신 사용자 정보가 올바르지 않습니다.',
+    });
+  }
+
+  static userIsExist(): HttpException {
+    return new BadRequestException({
+      statusCode: HttpStatus.BAD_REQUEST,
+      message: '이미 존재하는 회원입니다.',
+    });
+  }
+}

--- a/server/src/filter/http-exception.filter.ts
+++ b/server/src/filter/http-exception.filter.ts
@@ -11,7 +11,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
     response.status(status).json({
       statusCode: status,
       timestamp: new Date().toISOString(),
-      path: request.url,
+      path: process.env.API_SERVER_URL + request.url,
+      message: exception.message,
     });
   }
 }

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,8 +1,7 @@
 import { ValidationPipe } from '@nestjs/common';
 import * as cookieParser from 'cookie-parser';
 import { NestFactory } from '@nestjs/core';
-import * as dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
 import { AppModule } from './app.module';
 import { HttpExceptionFilter } from './filter/http-exception.filter';
 import { TransformInterceptor } from './filter/transform.interceptor';

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -5,6 +5,7 @@ import 'dotenv/config';
 import { AppModule } from './app.module';
 import { HttpExceptionFilter } from './filter/http-exception.filter';
 import { TransformInterceptor } from './filter/transform.interceptor';
+import { SwaggerConfig } from './config/swagger.config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -17,6 +18,7 @@ async function bootstrap() {
       transform: true,
     }),
   );
+  SwaggerConfig(app);
   await app.listen(3000);
 }
 


### PR DESCRIPTION
## 개요
- Room 관련 API 들 작업을 마무리했어요.
- Swagger 기본 설정을 진행했어요.
- 모든 API에서 공통으로 사용될 예외 클래스를 통합했어요.
- Builder 패턴을 적용했어요.


## 작업 사항
- Room 관련 API
    - 이제 uuid로 방의 정보를 조회할 수 있고 삭제할 수 있어요. 하지만 jwt가 있어야 작동한답니다.
      - jwt 유효성 검증만 하지 아직까진 인증된 사용자라면 다 삭제할 수 있어요.
      - 위험 요소가 있기에 해당 방의 주인이 아니라면 삭제가 불가능하도록 개선할 예정이에요.
    - 방 검색 API를 통합했어요.
      - 며칠 전 @jiho-bae 님이 짚어주신 개선 사항을 진행했어요.
      - 동일한 파라미터 구조, 함수 내부 구조를 갖고있기에 하나로 합치고 쿼리로 분기하도록 변경했어요.
      - 덕분에 room.controller 부분이 코드가 많이 줄어들었어요.
- Swagger 기본 설정
  - 기본 설정을 진행하고 room 검색 api 에만 적용해봤어요.
  - 근데 진행하다보니 코드가 너무 지저분해져서 고민이에요.
  - DTO 부분과 API Entry 부분에 모두 설명을 달아줘야해서 저거 조금 다는데도 시간이 좀 걸렸어요.
- 공통 예외 클래스
  - 기존엔 try ~ catch 혹은 예외 사항에 대한 exception을 길게 작성했어요.
  - 간단하게 사용할 수 있고 예외 메시지 같은 내용도 한번에 적을 수 있도록 외부에 분리했어요.
- Builder 패턴
  - Builder 패턴을 적용해봤는데 가독성이 엄청 늘어나서 행복해요.
  - 메소드 체이닝 방식처럼 쓰니까 세터들을 한번에 볼 수 있어요.


## 🧐고민고민
- Swagger 때문에 코드가 많이 지저분해진다.