### PR TITLE
s3 sdk 오류 해결 (이어서) 디폴트 이미지 로딩 (이어서) 방 접속 인원 소켓 (마침 다음 글)

### DIFF
--- a/server/api/src/builder/index.ts
+++ b/server/api/src/builder/index.ts
@@ -1,4 +1,5 @@
 export { RoomBuilder } from './room.builder';
 export { UserBuilder } from './user.builder';
-
+export { HistoryBuilder } from './history.builder';
+export { VisitBuilder } from './visit.builder';
 export { BuilderCommon } from './builder';

--- a/server/api/src/builder/visit.builder.ts
+++ b/server/api/src/builder/visit.builder.ts
@@ -1,0 +1,18 @@
+import { LocalDate } from 'js-joda';
+import { BuilderCommon } from './builder';
+import { Visit } from '../domain/history/visit.entity';
+export class VisitBuilder extends BuilderCommon<Visit> {
+  constructor() {
+    super(Visit);
+  }
+
+  setDate(date: LocalDate): VisitBuilder {
+    this.object.date = date;
+    return this;
+  }
+
+  setTotalVisit(totalVisit: number): VisitBuilder {
+    this.object.totalVisit = totalVisit;
+    return this;
+  }
+}

--- a/server/api/src/domain/auth/auth.repository.ts
+++ b/server/api/src/domain/auth/auth.repository.ts
@@ -18,7 +18,7 @@ export class AuthRepository extends Repository<User> {
     getConnection()
       .createQueryBuilder()
       .update(User)
-      .set({ isToday: false })
+      // .set({ isToday: false }) 이 부분은 변경 예정이라 일단 주석처리 했습니다. 오늘처리 해서 올릴게영
       .where('isToday = :checkIn', { checkIn: true })
       .execute();
   }

--- a/server/api/src/domain/auth/auth.repository.ts
+++ b/server/api/src/domain/auth/auth.repository.ts
@@ -1,3 +1,4 @@
+import { LocalDate } from 'js-joda';
 import { EntityRepository, getConnection, Repository } from 'typeorm';
 import { User } from '../user/user.entity';
 
@@ -14,20 +15,20 @@ export class AuthRepository extends Repository<User> {
     );
   }
 
-  updateCheckIn() {
-    getConnection()
-      .createQueryBuilder()
-      .update(User)
-      // .set({ isToday: false }) 이 부분은 변경 예정이라 일단 주석처리 했습니다. 오늘처리 해서 올릴게영
-      .where('isToday = :checkIn', { checkIn: true })
-      .execute();
-  }
-
   async findUserByEmail(email: string): Promise<User | undefined> {
     return await this.findOne({ where: { email: email }, relations: ['devField'] });
   }
 
   async findUserByNickname(nickname: string): Promise<User | undefined> {
     return await this.findOne({ where: { nickName: nickname }, relations: ['devField'] });
+  }
+
+  async getLastVisitCount() {
+    const yesterDay = LocalDate.now().minusDays(1);
+    return await this.createQueryBuilder('user')
+      .where('user.last_check_in = :date', {
+        date: yesterDay,
+      })
+      .getCount();
   }
 }

--- a/server/api/src/domain/auth/auth.repository.ts
+++ b/server/api/src/domain/auth/auth.repository.ts
@@ -26,8 +26,9 @@ export class AuthRepository extends Repository<User> {
   async getLastVisitCount() {
     const yesterDay = LocalDate.now().minusDays(1);
     return await this.createQueryBuilder('user')
-      .where('user.last_check_in = :date', {
-        date: yesterDay,
+      .where('user.last_check_in >= :dateS AND user.last_check_in <= :dateE', {
+        dateS: `${yesterDay['_year']}${yesterDay['_month']}${yesterDay['_day']} 00:00:00`,
+        dateE: `${yesterDay['_year']}${yesterDay['_month']}${yesterDay['_day']} 23:59:59`,
       })
       .getCount();
   }

--- a/server/api/src/domain/auth/service/auth.service.ts
+++ b/server/api/src/domain/auth/service/auth.service.ts
@@ -46,6 +46,7 @@ export class AuthService {
       .setNickName(nickname)
       .setEmail(email)
       .setPassword(Bcrypt.hash(password))
+      .setImageURL(process.env.DEFAULT_IMG)
       .build();
     await this.authRepository.save(user);
     return true;

--- a/server/api/src/domain/history/controller/history.controller.ts
+++ b/server/api/src/domain/history/controller/history.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../../auth/guard/jwt-auth-guard';
+import { HistoryService } from 'src/domain/history/service/history.service';
+
+@Controller('history')
+export class HistoryController {
+  constructor(private readonly historyService: HistoryService) {}
+
+  @Get()
+  @UseGuards(JwtAuthGuard)
+  async getUserInfo() {
+    return { result: await this.historyService.getLastVisitCount() };
+  }
+}

--- a/server/api/src/domain/history/history.module.ts
+++ b/server/api/src/domain/history/history.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { HistoryService } from './service/history.service';
 import { HistoryRepository } from './repository/history.repository';
 import { AuthRepository } from '../auth/auth.repository';
+import { VisitRepository } from './repository/visit.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([HistoryRepository, AuthRepository])],
+  imports: [TypeOrmModule.forFeature([HistoryRepository, AuthRepository, VisitRepository])],
   providers: [HistoryService],
   exports: [HistoryService],
 })

--- a/server/api/src/domain/history/repository/visit.repository.ts
+++ b/server/api/src/domain/history/repository/visit.repository.ts
@@ -9,7 +9,7 @@ export class VisitRepository extends Repository<Visit> {
     return await this.find({ where: { date: yesterDay } });
   }
 
-  async addVisitCount(count) {
+  async addVisitCount(count: number) {
     const visit: Visit = new Visit();
     visit.date = LocalDate.now().minusDays(1);
     visit.totalVisit = count;

--- a/server/api/src/domain/history/repository/visit.repository.ts
+++ b/server/api/src/domain/history/repository/visit.repository.ts
@@ -1,0 +1,18 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { LocalDate } from 'js-joda';
+import { Visit } from '../visit.entity';
+
+@EntityRepository(Visit)
+export class VisitRepository extends Repository<Visit> {
+  async getVisitCount() {
+    const yesterDay: LocalDate = LocalDate.now().minusDays(1);
+    return await this.find({ where: { date: yesterDay } });
+  }
+
+  async addVisitCount(count) {
+    const visit: Visit = new Visit();
+    visit.date = LocalDate.now().minusDays(1);
+    visit.totalVisit = count;
+    this.save(visit);
+  }
+}

--- a/server/api/src/domain/history/repository/visit.repository.ts
+++ b/server/api/src/domain/history/repository/visit.repository.ts
@@ -1,6 +1,7 @@
 import { EntityRepository, Repository } from 'typeorm';
 import { LocalDate } from 'js-joda';
 import { Visit } from '../visit.entity';
+import { VisitBuilder } from 'src/builder/visit.builder';
 
 @EntityRepository(Visit)
 export class VisitRepository extends Repository<Visit> {
@@ -10,9 +11,7 @@ export class VisitRepository extends Repository<Visit> {
   }
 
   async addVisitCount(count: number) {
-    const visit: Visit = new Visit();
-    visit.date = LocalDate.now().minusDays(1);
-    visit.totalVisit = count;
+    const visit: Visit = new VisitBuilder().setDate(LocalDate.now().minusDays(1)).setTotalVisit(count).build();
     this.save(visit);
   }
 }

--- a/server/api/src/domain/history/service/history.service.ts
+++ b/server/api/src/domain/history/service/history.service.ts
@@ -4,12 +4,15 @@ import { UserException } from 'src/exception';
 import { User } from 'src/domain/user/user.entity';
 import { AuthRepository } from 'src/domain/auth/auth.repository';
 import { HistoryRepository } from '../repository/history.repository';
+import { VisitRepository } from '../repository/visit.repository';
 
 @Injectable()
 export class HistoryService {
   constructor(
     @InjectRepository(HistoryRepository)
     private readonly historyRepository: HistoryRepository,
+    @InjectRepository(VisitRepository)
+    private readonly visitRepository: VisitRepository,
     @InjectRepository(AuthRepository)
     private readonly authRepository: AuthRepository,
   ) {}
@@ -22,5 +25,9 @@ export class HistoryService {
     const user: User = await this.authRepository.findUserByNickname(nickname);
     if (!user) throw UserException.userNotFound();
     return await this.historyRepository.getHistoryByNickname(user);
+  }
+
+  async getLastVisitCount() {
+    return await this.visitRepository.getVisitCount();
   }
 }

--- a/server/api/src/domain/history/visit.entity.ts
+++ b/server/api/src/domain/history/visit.entity.ts
@@ -1,0 +1,15 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { LocalDate } from 'js-joda';
+import { LocalDateTransformer } from '../../transformer/LocalDateTransformer';
+
+@Entity()
+export class Visit {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'timestamp', transformer: new LocalDateTransformer() })
+  date: LocalDate;
+
+  @Column()
+  totalVisit: number;
+}

--- a/server/api/src/domain/history/visit.entity.ts
+++ b/server/api/src/domain/history/visit.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { LocalDate } from 'js-joda';
 import { LocalDateTransformer } from '../../transformer/LocalDateTransformer';
 

--- a/server/api/src/domain/image/service/image.service.ts
+++ b/server/api/src/domain/image/service/image.service.ts
@@ -30,7 +30,7 @@ export class ImageService {
   async uploadImage(image: Express.Multer.File): Promise<ObjectStorageData> {
     const param = {
       Bucket: process.env.NCP_BUCKET_NAME ?? '',
-      Key: `${Date.now()}-${image.originalname}`,
+      Key: encodeURI(`${Date.now()}-${image.originalname}`),
       ACL: 'public-read',
       Body: image.buffer,
     };

--- a/server/api/src/domain/user/controller/user.controller.ts
+++ b/server/api/src/domain/user/controller/user.controller.ts
@@ -41,14 +41,14 @@ export class UserController {
   @Post('/:userId/image')
   @UseGuards(JwtAuthGuard)
   @UseInterceptors(FileInterceptor('image'))
-  async uploadUserImage(@Param('userId') nickname: string, @UploadedFile() file) {
+  async uploadUserImage(@Param('userId') nickname: string, @UploadedFile() file: Express.Multer.File) {
     return { result: await this.userService.updateImage(nickname, file) };
   }
 
   @Patch('/:userId/image')
   @UseGuards(JwtAuthGuard)
   @UseInterceptors(FileInterceptor('image'))
-  async patchUserImage(@Param('userId') nickname: string, @UploadedFile() file) {
+  async patchUserImage(@Param('userId') nickname: string, @UploadedFile() file: Express.Multer.File) {
     return { result: await this.userService.updateImage(nickname, file) };
   }
 

--- a/server/api/src/domain/user/controller/user.controller.ts
+++ b/server/api/src/domain/user/controller/user.controller.ts
@@ -41,14 +41,14 @@ export class UserController {
   @Post('/:userId/image')
   @UseGuards(JwtAuthGuard)
   @UseInterceptors(FileInterceptor('image'))
-  async uploadUserImage(@Param('userId') nickname: string, @UploadedFile() file: Express.Multer.File) {
+  async uploadUserImage(@Param('userId') nickname: string, @UploadedFile() file) {
     return { result: await this.userService.updateImage(nickname, file) };
   }
 
   @Patch('/:userId/image')
   @UseGuards(JwtAuthGuard)
   @UseInterceptors(FileInterceptor('image'))
-  async patchUserImage(@Param('userId') nickname: string, @UploadedFile() file: Express.Multer.File) {
+  async patchUserImage(@Param('userId') nickname: string, @UploadedFile() file) {
     return { result: await this.userService.updateImage(nickname, file) };
   }
 

--- a/server/api/src/domain/user/service/user.service.ts
+++ b/server/api/src/domain/user/service/user.service.ts
@@ -38,7 +38,7 @@ export class UserService {
     return true;
   }
 
-  async updateImage(nickname: string, file: ObjectStorageData) {
+  async updateImage(nickname: string, file) {
     const updateUser: User = await this.authRepository.findUserByNickname(nickname);
     if (!updateUser) throw UserException.userNotFound();
     if (updateUser.imageName) await this.imageService.deleteImage(updateUser.imageName);

--- a/server/api/src/domain/user/service/user.service.ts
+++ b/server/api/src/domain/user/service/user.service.ts
@@ -54,7 +54,7 @@ export class UserService {
     if (!updateUser) throw UserException.userNotFound();
     if (!updateUser.imageName) return true;
     await this.imageService.deleteImage(updateUser.imageName);
-    updateUser.setImageUrl('');
+    updateUser.setImageUrl(process.env.NCP_BUCKET_NAME);
     updateUser.setImageName('');
     await this.authRepository.save(updateUser);
     return true;

--- a/server/api/src/domain/user/service/user.service.ts
+++ b/server/api/src/domain/user/service/user.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { UserException, DevFieldException } from '../../../exception';
 import { User } from '../user.entity';
 import { DevField } from '../dev-field.entity';
-import { ImageService, ObjectStorageData } from '../../image/service/image.service';
+import { ImageService } from '../../image/service/image.service';
 import { DevFieldRepository } from '../repository/dev-field.repository';
 import { AuthRepository } from '../../auth/auth.repository';
 import { UserUpdateDto } from '../dto/user-update.dto';

--- a/server/api/src/domain/user/user.entity.ts
+++ b/server/api/src/domain/user/user.entity.ts
@@ -3,6 +3,8 @@ import { Bcrypt } from 'src/utils/bcrypt';
 import { DevField } from './dev-field.entity';
 import { Follow } from './follow.entity';
 import { History } from '../history/history.entity';
+import { LocalDateTransformer } from 'src/transformer/LocalDateTransformer';
+import { LocalDate } from 'js-joda';
 
 @Entity()
 export class User {
@@ -40,8 +42,8 @@ export class User {
   @OneToMany(() => History, (history) => history.user)
   historys: History[];
 
-  @Column({ default: false })
-  isToday: boolean;
+  @Column({ type: 'timestamp', transformer: new LocalDateTransformer() })
+  lastCheckIn: LocalDate;
 
   setNickname(nickname: string) {
     this.nickName = nickname;
@@ -69,7 +71,7 @@ export class User {
     this.devField = devField;
   }
 
-  setIsToday(isToday: boolean) {
-    this.isToday = isToday;
+  setLastCheckIn(lastCheckIn: LocalDate) {
+    this.lastCheckIn = lastCheckIn;
   }
 }

--- a/server/api/src/scheduler/scheduler.module.ts
+++ b/server/api/src/scheduler/scheduler.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { SchedulerService } from './scheduler.service';
 import { AuthRepository } from 'src/domain/auth/auth.repository';
+import { VisitRepository } from 'src/domain/history/repository/visit.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AuthRepository])],
+  imports: [TypeOrmModule.forFeature([AuthRepository, VisitRepository])],
   providers: [SchedulerService],
 })
 export class SchedulerModule {}

--- a/server/api/src/scheduler/scheduler.service.ts
+++ b/server/api/src/scheduler/scheduler.service.ts
@@ -2,15 +2,19 @@ import { Injectable } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AuthRepository } from 'src/domain/auth/auth.repository';
+import { VisitRepository } from 'src/domain/history/repository/visit.repository';
 
 @Injectable()
 export class SchedulerService {
   constructor(
     @InjectRepository(AuthRepository)
     private readonly authRepository: AuthRepository,
+    @InjectRepository(VisitRepository)
+    private readonly visitRepository: VisitRepository,
   ) {}
   @Cron('0 0 * * *')
-  handleCron() {
-    this.authRepository.updateCheckIn();
+  async handleCron() {
+    const count = await this.authRepository.getLastVisitCount();
+    this.visitRepository.addVisitCount(count);
   }
 }

--- a/server/socket/src/app.gateway.ts
+++ b/server/socket/src/app.gateway.ts
@@ -22,6 +22,20 @@ export class AppGateway implements OnGatewayInit, OnGatewayConnection, OnGateway
     this.server.emit('msgToClient', payload);
   }
 
+  @SubscribeMessage('join-room')
+  handleJoinRoom(client: Socket, payload): void {
+    client.join(payload.roomId);
+    this.logger.log(`${payload.nickname}님이 ${payload.roomId}에 입장!! 🎉✨🎊`);
+    if (!this.userList[payload.roomId]) this.userList[payload.roomId] = [];
+    const user = {
+      nickname: payload.nickname,
+      field: payload.field,
+      img: payload.img,
+    };
+    this.userList[payload.roomId].push(user);
+    this.server.to(payload.roomId).emit('user-list', this.userList[payload.roomId]);
+  }
+
   afterInit(server: Server) {
     this.logger.log('Init');
   }

--- a/server/socket/src/app.gateway.ts
+++ b/server/socket/src/app.gateway.ts
@@ -38,6 +38,8 @@ export class AppGateway implements OnGatewayInit, OnGatewayConnection, OnGateway
   handleLeaveRoom(client: Socket, payload): void {
     client.leave(payload.roomId);
     this.logger.log(`${payload.nickname}님이 ${payload.roomId}에서 퇴장!! 😭😥😫`);
+    delete this.userList[payload.roomId][payload.nickname];
+    this.server.to(payload.roomId).emit('user-list', this.userList[payload.roomId]);
   }
 
   afterInit(server: Server) {

--- a/server/socket/src/app.gateway.ts
+++ b/server/socket/src/app.gateway.ts
@@ -26,7 +26,7 @@ export class AppGateway implements OnGatewayInit, OnGatewayConnection, OnGateway
   handleJoinRoom(client: Socket, payload): void {
     client.join(payload.roomId);
     this.logger.log(`${payload.nickname}님이 ${payload.roomId}에 입장!! 🎉✨🎊`);
-    if (!this.userList[payload.roomId]) this.userList[payload.roomId] = [];
+    if (!this.userList[payload.roomId]) this.userList[payload.roomId] = {};
     const user = {
       nickname: payload.nickname,
       field: payload.field,
@@ -34,6 +34,11 @@ export class AppGateway implements OnGatewayInit, OnGatewayConnection, OnGateway
     };
     this.userList[payload.roomId].push(user);
     this.server.to(payload.roomId).emit('user-list', this.userList[payload.roomId]);
+  }
+  @SubscribeMessage('leave-room')
+  handleLeaveRoom(client: Socket, payload): void {
+    client.leave(payload.roomId);
+    this.logger.log(`${payload.nickname}님이 ${payload.roomId}에서 퇴장!! 😭😥😫`);
   }
 
   afterInit(server: Server) {

--- a/server/socket/src/app.gateway.ts
+++ b/server/socket/src/app.gateway.ts
@@ -27,12 +27,11 @@ export class AppGateway implements OnGatewayInit, OnGatewayConnection, OnGateway
     client.join(payload.roomId);
     this.logger.log(`${payload.nickname}님이 ${payload.roomId}에 입장!! 🎉✨🎊`);
     if (!this.userList[payload.roomId]) this.userList[payload.roomId] = {};
-    const user = {
-      nickname: payload.nickname,
+    const userInfo = {
       field: payload.field,
       img: payload.img,
     };
-    this.userList[payload.roomId].push(user);
+    this.userList[payload.roomId][payload.nickname] = userInfo;
     this.server.to(payload.roomId).emit('user-list', this.userList[payload.roomId]);
   }
   @SubscribeMessage('leave-room')

--- a/server/socket/src/app.gateway.ts
+++ b/server/socket/src/app.gateway.ts
@@ -12,6 +12,7 @@ import { Logger } from '@nestjs/common';
 
 @WebSocketGateway()
 export class AppGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
+  userList = {};
   @WebSocketServer() server: Server;
   private logger: Logger = new Logger('AppGateway');
 


### PR DESCRIPTION
## 개요
- 어느 순간 오브젝트 스토리지 리스트를 확인하려 하면 aws s3 sdk error라는 메세지가 떠서 네이버에 문의를 해보니 한글 파일명을 업로드 할 때 파일명을 인코딩하라는군요.. 그래서 인코딩해서 저장합니당.
- 디폴트 아바타 이미지를 서버에서 저장하기로 했습니다. 회원가입하거나 기존에 있던 아바타 이미지를 지우면 디폴트 이미지로 변경됩니다.
- 방 접속 인원 조회 기능을 적용했습니다. join-room을 하면 특정 방 접속 리스트에 등록이 되고 leave-room을 하면 특정 방 접속 리스트에서 삭제됩니다. 리스트 관리를 어떻게 할까 고민을 하다가 데이터베이스에 넣고 관리할까 했는데 이런 기능은 Redis를 사용해야 한다고 하더라고요. 그래서 낼 땡구님이 레디스 연동 해주시면 Redis 코드에 맞게 쉽게 변형할 수 있도록 리스트를 key-value 형식으로 관리하고 있습니다. 

```json
{
"first-room":{
      "hoon":{
            "field":"back-end",
            "img":"https://tadak-tadak.kr.object.ncloudstorage.com/1637058377523-default-avatar.jpeg"
      },
      "ho":{
            "field":"front-end",
            "img":"https://tadak-tadak.kr.object.ncloudstorage.com/1637058377523-default-avatar.jpeg"
      }
},
"second-room":{
      "beom":{
            "field":"back-end",
            "img":"이미지 url",
      },
      "byeol":{
            "fied":"front-end",
            "img":"이미지 url"
      },
}
}
```
- 메인 페이지에서 방 리스트만 뜨는 것이 좀 심심한 거 같아서 싸이월드 today같은(타닥타닥에서는 yesterday입니다 ㅎㅎ) API를 추가했습니다.. 프론트 작업 하시는 분들이 바쁘실 거 같아서 제가 작업해놓겠습니다!
## 작업 사항
- s3 한글 파일 저장 오류 해결
- 회원 가입 및 아바타 삭제 시 디폴트 이미지로 변경
- 방 접속 사용자 리스트 소켓 기능
- 스케줄러로 yesterday 접속 수 계산후 visit 테이블에 저장


## 🧐고민고민
아까 지호님한테 여쭤봤던 내용입니다.
타닥타닥 방에서 사이드 바에는 채팅 탭과 접속 인원 탭이 있습니다.
두 개의 탭 중 하나를 선택하면 다른 탭의 정보는 가려집니다.
만약 접속 인원 탭이 선택된 상태에서 새 채팅이 도착하면 채팅 탭이 보이지 않더라도 새 메세지가 렌더링이 되는거겠죠?

