### PR TITLE
소켓 참가자와 채팅 목록 연동, 방 사이드바에 적용

### DIFF
--- a/client/craco.config.js
+++ b/client/craco.config.js
@@ -6,7 +6,7 @@ module.exports = {
       plugin: CracoAlias,
       options: {
         source: 'tsconfig',
-        baseUrl: './src',
+        baseUrl: '.',
         tsConfigPath: 'tsconfig.paths.json',
       },
     },

--- a/client/src/components/main/CreateForm.tsx
+++ b/client/src/components/main/CreateForm.tsx
@@ -83,8 +83,8 @@ const CreateForm = (): JSX.Element => {
     };
     const { isOk, data } = await postRoom(requestBody);
     if (isOk && data) {
-      const { room } = data;
-      history.push(`/room/${room?.uuid}`, room);
+      const { uuid } = data;
+      history.push(`/room/${uuid}`, data);
     }
   };
 

--- a/client/src/components/main/CreateForm.tsx
+++ b/client/src/components/main/CreateForm.tsx
@@ -83,8 +83,8 @@ const CreateForm = (): JSX.Element => {
     };
     const { isOk, data } = await postRoom(requestBody);
     if (isOk && data) {
-      const { uuid } = data;
-      history.push(`/room/${uuid}`, data);
+      const { room } = data;
+      history.push(`/room/${room?.uuid}`, room);
     }
   };
 

--- a/client/src/components/room/tadaktadak/ChatList.tsx
+++ b/client/src/components/room/tadaktadak/ChatList.tsx
@@ -1,8 +1,8 @@
-import { useUser } from '@contexts/userContext';
-import useInput from '@hooks/useInput';
 import React, { useCallback, useEffect } from 'react';
 import styled from 'styled-components';
-import socket from '../../../socket';
+import { useUser } from '@contexts/userContext';
+import useInput from '@hooks/useInput';
+import socket from '@src/socket';
 
 const INPUT_WIDTH = '90%';
 const CHAT_LIST_HEIGHT = '90%';

--- a/client/src/components/room/tadaktadak/ChatList.tsx
+++ b/client/src/components/room/tadaktadak/ChatList.tsx
@@ -75,10 +75,9 @@ const ChatList = ({ uuid, chats, setChats }: ChatListProps<string>): JSX.Element
 
   const sendMessage = useCallback(() => {
     const myMessage = { type: 'string', nickname, message, roomId: uuid };
-    setChats([...chats, myMessage]);
-    onResetMessage();
     socket.emit('msgToServer', myMessage);
-  }, [setChats, onResetMessage, nickname, chats, message, uuid]);
+    onResetMessage();
+  }, [onResetMessage, nickname, message, uuid]);
 
   const onKeyPress = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => e.key === 'Enter' && sendMessage(),

--- a/client/src/components/room/tadaktadak/ChatList.tsx
+++ b/client/src/components/room/tadaktadak/ChatList.tsx
@@ -10,6 +10,7 @@ const CHAT_INPUT_HEIGHT = '10%';
 
 interface ChatListProps<T> {
   chats: Array<Record<string, T | undefined>>;
+  uuid: string;
   setChats: React.Dispatch<React.SetStateAction<Array<Record<string, T | undefined>>>>;
 }
 
@@ -63,16 +64,16 @@ const Line = styled.div`
   margin: 0 auto;
 `;
 
-const ChatList = ({ chats, setChats }: ChatListProps<string>): JSX.Element => {
+const ChatList = ({ uuid, chats, setChats }: ChatListProps<string>): JSX.Element => {
   const { nickname } = useUser();
   const [message, onChangeMessage, onResetMessage] = useInput('');
 
   const sendMessage = useCallback(() => {
-    const myMessage = { type: 'string', nickname, message };
+    const myMessage = { type: 'string', nickname, message, roomId: uuid };
     setChats([...chats, myMessage]);
     onResetMessage();
     socket.emit('msgToServer', myMessage);
-  }, [setChats, onResetMessage, nickname, chats, message]);
+  }, [setChats, onResetMessage, nickname, chats, message, uuid]);
 
   const onKeyPress = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => e.key === 'Enter' && sendMessage(),
@@ -81,6 +82,7 @@ const ChatList = ({ chats, setChats }: ChatListProps<string>): JSX.Element => {
 
   const handleMessageReceive = useCallback(
     (data) => {
+      console.log('qqqqq', data);
       setChats([...chats, data]);
     },
     [chats, setChats],

--- a/client/src/components/room/tadaktadak/ChatList.tsx
+++ b/client/src/components/room/tadaktadak/ChatList.tsx
@@ -45,16 +45,21 @@ const Input = styled.input`
 `;
 
 const Chat = styled.li`
+  display: flex;
   :not(:first-of-type) {
     margin-top: ${({ theme }) => theme.margins.base};
   }
 `;
 
-const ChatInfo = styled.p``;
+const ChatNickname = styled.span`
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
+  font-size: ${({ theme }) => theme.fontSizes.lg};
+`;
 
 const ChatMesssage = styled.p`
-  margin-top: 0.4rem;
-  font-size: ${({ theme }) => theme.fontSizes.sm};
+  width: 100%;
+  margin-left: ${({ theme }) => theme.margins.base};
+  font-size: ${({ theme }) => theme.fontSizes.base};
 `;
 
 const Line = styled.div`
@@ -80,13 +85,7 @@ const ChatList = ({ uuid, chats, setChats }: ChatListProps<string>): JSX.Element
     [sendMessage],
   );
 
-  const handleMessageReceive = useCallback(
-    (data) => {
-      console.log('qqqqq', data);
-      setChats([...chats, data]);
-    },
-    [chats, setChats],
-  );
+  const handleMessageReceive = useCallback((data) => setChats([...chats, data]), [chats, setChats]);
 
   useEffect(() => {
     socket.on('msgToClient', handleMessageReceive);
@@ -95,10 +94,10 @@ const ChatList = ({ uuid, chats, setChats }: ChatListProps<string>): JSX.Element
   return (
     <Container>
       <List>
-        {chats.length &&
+        {chats.length > 0 &&
           Object.values(chats).map((chat) => (
             <Chat>
-              <ChatInfo></ChatInfo>
+              <ChatNickname>{chat.nickname}</ChatNickname>
               <ChatMesssage>{chat.message}</ChatMesssage>
             </Chat>
           ))}

--- a/client/src/components/room/tadaktadak/ChatList.tsx
+++ b/client/src/components/room/tadaktadak/ChatList.tsx
@@ -94,8 +94,8 @@ const ChatList = ({ uuid, chats, setChats }: ChatListProps<string>): JSX.Element
     <Container>
       <List>
         {chats.length > 0 &&
-          Object.values(chats).map((chat) => (
-            <Chat>
+          Object.values(chats).map((chat, idx) => (
+            <Chat key={idx}>
               <ChatNickname>{chat.nickname}</ChatNickname>
               <ChatMesssage>{chat.message}</ChatMesssage>
             </Chat>

--- a/client/src/components/room/tadaktadak/ParticipantList.tsx
+++ b/client/src/components/room/tadaktadak/ParticipantList.tsx
@@ -17,8 +17,26 @@ const List = styled.ul`
 `;
 
 const Participant = styled.li`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
   margin-bottom: ${({ theme }) => theme.margins.sm};
 `;
+
+const Avatar = styled.img`
+  margin-right: ${({ theme }) => theme.margins.base};
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  overflow: hidden;
+`;
+
+const Nickname = styled.span`
+  font-size: ${({ theme }) => theme.fontSizes.lg};
+`;
+
+const DevField = styled.div``;
 
 const ParticipantList = ({ participants }: ParticipantListProps<any>): JSX.Element => {
   return (
@@ -26,9 +44,9 @@ const ParticipantList = ({ participants }: ParticipantListProps<any>): JSX.Eleme
       <List>
         {Object.entries(participants).map(([nickname, { field, img }]) => (
           <Participant key={nickname}>
-            {nickname}
-            {field}
-            {img}
+            <Avatar src={img} />
+            <Nickname>{nickname}</Nickname>
+            {field && <DevField>{field}</DevField>}
           </Participant>
         ))}
       </List>

--- a/client/src/components/room/tadaktadak/ParticipantList.tsx
+++ b/client/src/components/room/tadaktadak/ParticipantList.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 interface ParticipantListProps<T> {
-  participants: Array<T>;
+  participants: Record<string, T>;
 }
 
 const Container = styled.div`
@@ -38,7 +38,7 @@ const Nickname = styled.span`
 
 const DevField = styled.div``;
 
-const ParticipantList = ({ participants }: ParticipantListProps<any>): JSX.Element => {
+const ParticipantList = ({ participants }: ParticipantListProps<{ field: string; img: string }>): JSX.Element => {
   return (
     <Container>
       <List>

--- a/client/src/components/room/tadaktadak/ParticipantList.tsx
+++ b/client/src/components/room/tadaktadak/ParticipantList.tsx
@@ -24,8 +24,12 @@ const ParticipantList = ({ participants }: ParticipantListProps<any>): JSX.Eleme
   return (
     <Container>
       <List>
-        {participants.map(({ nickname }, idx) => (
-          <Participant key={idx}>{nickname}</Participant>
+        {Object.entries(participants).map(([nickname, { field, img }]) => (
+          <Participant key={nickname}>
+            {nickname}
+            {field}
+            {img}
+          </Participant>
         ))}
       </List>
     </Container>

--- a/client/src/components/room/tadaktadak/RoomSideBar.tsx
+++ b/client/src/components/room/tadaktadak/RoomSideBar.tsx
@@ -42,7 +42,7 @@ interface RoomSideBarProps {
 const RoomSideBar = ({ uuid }: RoomSideBarProps): JSX.Element => {
   const { nickname, devField, imageUrl } = useUser();
   const [tabs, setTabs] = useState({ ...initialTabState });
-  const [chats, setChats] = useState([{ message: 'hello' }, { message: 'hi' }]);
+  const [chats, setChats] = useState<Array<Record<string, string | undefined>>>([]);
   const [participants, setParticipants] = useState({});
   const { isChat, isParticipant } = tabs;
 

--- a/client/src/components/room/tadaktadak/RoomSideBar.tsx
+++ b/client/src/components/room/tadaktadak/RoomSideBar.tsx
@@ -43,12 +43,7 @@ const RoomSideBar = ({ uuid }: RoomSideBarProps): JSX.Element => {
   const { nickname, devField, imageUrl } = useUser();
   const [tabs, setTabs] = useState({ ...initialTabState });
   const [chats, setChats] = useState([{ message: 'hello' }, { message: 'hi' }]);
-  const [participants, setParticipants] = useState([
-    { nickname: 'Tom' },
-    { nickname: 'James' },
-    { nickname: 'Work' },
-    { nickname: 'Bob' },
-  ]);
+  const [participants, setParticipants] = useState({});
   const { isChat, isParticipant } = tabs;
 
   const onClickChatTap = () => setTabs({ ...initialTabState, isChat: !isChat });

--- a/client/src/components/room/tadaktadak/RoomSideBar.tsx
+++ b/client/src/components/room/tadaktadak/RoomSideBar.tsx
@@ -74,7 +74,7 @@ const RoomSideBar = ({ uuid }: RoomSideBarProps): JSX.Element => {
         </SideBarTabs>
       </SideBarTopMenus>
       <SideBarBottomMenus>
-        {isChat && <ChatList chats={chats} setChats={setChats} />}
+        {isChat && <ChatList chats={chats} uuid={uuid} setChats={setChats} />}
         {isParticipant && <ParticipantList participants={participants} />}
       </SideBarBottomMenus>
     </SideBarContainer>

--- a/client/src/components/room/tadaktadak/RoomSideBar.tsx
+++ b/client/src/components/room/tadaktadak/RoomSideBar.tsx
@@ -4,7 +4,7 @@ import Tab from '@components/common/Tab';
 import ChatList from './ChatList';
 import ParticipantList from './ParticipantList';
 import { useUser } from '@contexts/userContext';
-import socket from '../../../socket';
+import socket from '@src/socket';
 
 const SIDEBAR_MIN_WIDTH = '29rem';
 const SIDEBAR_HEIGHT = '100vh';

--- a/client/src/components/room/tadaktadak/RoomSideBar.tsx
+++ b/client/src/components/room/tadaktadak/RoomSideBar.tsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Tab from '@components/common/Tab';
 import ChatList from './ChatList';
 import ParticipantList from './ParticipantList';
+import { useUser } from '@contexts/userContext';
+import socket from '../../../socket';
 
 const SIDEBAR_MIN_WIDTH = '29rem';
 const SIDEBAR_HEIGHT = '100vh';
@@ -33,7 +35,12 @@ const initialTabState = {
   isParticipant: false,
 };
 
-const RoomSideBar = (): JSX.Element => {
+interface RoomSideBarProps {
+  uuid: string;
+}
+
+const RoomSideBar = ({ uuid }: RoomSideBarProps): JSX.Element => {
+  const { nickname, devField, imageUrl } = useUser();
   const [tabs, setTabs] = useState({ ...initialTabState });
   const [chats, setChats] = useState([{ message: 'hello' }, { message: 'hi' }]);
   const [participants, setParticipants] = useState([
@@ -46,6 +53,22 @@ const RoomSideBar = (): JSX.Element => {
 
   const onClickChatTap = () => setTabs({ ...initialTabState, isChat: !isChat });
   const onClickParticipantTap = () => setTabs({ ...initialTabState, isParticipant: !isParticipant });
+
+  const initSocket = useCallback(() => {
+    const joinPayload = { nickname, roomId: uuid, field: devField, img: imageUrl };
+    socket.emit('join-room', joinPayload);
+    socket.on('user-list', (data) => setParticipants({ ...data }));
+  }, [nickname, devField, imageUrl, uuid]);
+
+  const leaveSocket = useCallback(() => {
+    const leavePayload = { nickname, roomId: uuid };
+    socket.emit('leave-room', leavePayload);
+  }, [nickname, uuid]);
+
+  useEffect(() => {
+    initSocket();
+    return leaveSocket;
+  }, [initSocket, leaveSocket]);
 
   return (
     <SideBarContainer>

--- a/client/src/components/room/tadaktadak/VideoController.tsx
+++ b/client/src/components/room/tadaktadak/VideoController.tsx
@@ -7,6 +7,8 @@ import styled, { css, ThemeContext } from 'styled-components';
 import { useClient } from './videoConfig';
 import Button from '@components/common/Button';
 import ScreenShareDiv from './ScreenShareDiv';
+import { deleteRoom } from '@utils/apis';
+import { useUser } from '@contexts/userContext';
 
 const ButtonContainer = styled.div``;
 const Controls = styled.div`
@@ -30,12 +32,15 @@ const GetoutDiv = styled.div`
 interface VideoControllerProps {
   tracks: [IMicrophoneAudioTrack, ICameraVideoTrack];
   setStart: React.Dispatch<React.SetStateAction<boolean>>;
+  uuid: string;
+  ownerId: number | undefined;
 }
 
-const VideoController = ({ tracks, setStart }: VideoControllerProps): JSX.Element => {
+const VideoController = ({ tracks, setStart, uuid, ownerId }: VideoControllerProps): JSX.Element => {
   const client = useClient();
   const history = useHistory();
   const themeContext = useContext(ThemeContext);
+  const user = useUser();
   const [trackState, setTrackState] = useState({ video: false, audio: false });
   const [screenShare, setScreenShare] = useState(false);
 
@@ -57,12 +62,13 @@ const VideoController = ({ tracks, setStart }: VideoControllerProps): JSX.Elemen
   const handleScreenShare = () => setScreenShare(true);
 
   const leaveChannel = useCallback(async () => {
+    if (ownerId === user.id) deleteRoom({ uuid });
     await client.leave();
     client.removeAllListeners();
     tracks[0].close();
     tracks[1].close();
     setStart(false);
-  }, [client, tracks, setStart]);
+  }, [client, tracks, uuid, ownerId, user, setStart]);
 
   useEffect(() => {
     return history.listen(() => {

--- a/client/src/contexts/userContext.tsx
+++ b/client/src/contexts/userContext.tsx
@@ -7,7 +7,7 @@ export interface UserProps {
   imageUrl?: string;
   introduction?: string;
   isSocial?: boolean;
-  dev_field?: {
+  devField?: {
     id: number;
     name: string;
   };

--- a/client/src/pages/Main/Main.tsx
+++ b/client/src/pages/Main/Main.tsx
@@ -4,12 +4,13 @@ import RoomBox from '@components/RoomBox';
 import SideBar from '@components/main/SideBar';
 import ListGenerator from '@components/ListGenerator';
 import { getRoom } from '@utils/apis';
+import { UserProps } from '@contexts/userContext';
 
 export interface RoomInfo {
   agoraAppId: string;
   agoraToken: string;
   uuid: string;
-  ownerId: number;
+  owner?: UserProps;
   title: string;
   roomType: string;
   description: string;

--- a/client/src/pages/Room/Room.tsx
+++ b/client/src/pages/Room/Room.tsx
@@ -74,7 +74,7 @@ const Room = ({ location }: RoomProps): JSX.Element => {
 
   return (
     <RoomWrapper>
-      <RoomSideBar />
+      <RoomSideBar uuid={uuid} />
       <RoomContainer>
         {start && tracks && <Videos users={users} tracks={tracks} />}
         {ready && tracks && <VideoController tracks={tracks} setStart={setStart} />}

--- a/client/src/pages/Room/Room.tsx
+++ b/client/src/pages/Room/Room.tsx
@@ -17,7 +17,7 @@ interface RoomProps {
 }
 
 const Room = ({ location }: RoomProps): JSX.Element => {
-  const { agoraAppId, agoraToken, uuid } = location.state;
+  const { agoraAppId, agoraToken, uuid, owner } = location.state;
   const [users, setUsers] = useState<IAgoraRTCRemoteUser[]>([]);
   const [start, setStart] = useState<boolean>(false); // start: 서버에 초기화 완료
   const client = useClient();
@@ -77,7 +77,7 @@ const Room = ({ location }: RoomProps): JSX.Element => {
       <RoomSideBar uuid={uuid} />
       <RoomContainer>
         {start && tracks && <Videos users={users} tracks={tracks} />}
-        {ready && tracks && <VideoController tracks={tracks} setStart={setStart} />}
+        {ready && tracks && <VideoController tracks={tracks} setStart={setStart} uuid={uuid} ownerId={owner?.id} />}
       </RoomContainer>
     </RoomWrapper>
   );

--- a/client/src/utils/apiUtils.ts
+++ b/client/src/utils/apiUtils.ts
@@ -46,6 +46,16 @@ function postOptions(body: BodyType): RequestInit {
   };
 }
 
+function deleteOptions(): RequestInit {
+  return {
+    method: 'DELETE',
+    headers: {
+      Accept: 'application/json',
+    },
+    credentials: 'include',
+  };
+}
+
 export async function fetcher<T>(url: string, options: RequestInit): Promise<HTTPResponse<T>> {
   try {
     const response = await fetch(url, options);
@@ -80,7 +90,12 @@ export async function fetchGet<T>(url: string, query?: string): Promise<HTTPResp
 }
 
 export async function fetchPost<T>(url: string, body: BodyType): Promise<HTTPResponse<T>> {
-  const requestUrl = getUrl(`${url}`);
+  const requestUrl = getUrl(url);
   const response = await fetcher<T>(requestUrl, postOptions(body));
   return response;
+}
+
+export function fetchDelete(url: string): void {
+  const requestUrl = getUrl(url);
+  fetcher(requestUrl, deleteOptions());
 }

--- a/client/src/utils/apis.ts
+++ b/client/src/utils/apis.ts
@@ -34,8 +34,8 @@ interface PostRoom {
   roomType: string;
 }
 
-export const postRoom = async (body: PostRoom): Promise<HTTPResponse<{ room: RoomInfo }>> => {
-  const response = await fetchPost<{ room: RoomInfo }>('/api/room', { ...body });
+export const postRoom = async (body: PostRoom): Promise<HTTPResponse<RoomInfo>> => {
+  const response = await fetchPost<RoomInfo>('/api/room', { ...body });
   return response;
 };
 

--- a/client/src/utils/apis.ts
+++ b/client/src/utils/apis.ts
@@ -1,6 +1,6 @@
 import { UserProps } from '@contexts/userContext';
 import { RoomInfo } from '@pages/Main/Main';
-import { HTTPResponse, queryObjToString, fetchGet, fetchPost } from './apiUtils';
+import { HTTPResponse, queryObjToString, fetchGet, fetchPost, fetchDelete } from './apiUtils';
 
 interface PostLogin {
   email: string;
@@ -57,3 +57,9 @@ export const getRoom = async (queryObj: GetRoomQueryObj): Promise<HTTPResponse<R
   const response = await fetchGet<ResponseGetRoomData>('/api/room', queryString);
   return response;
 };
+
+interface DeleteRoom {
+  uuid: string;
+}
+
+export const deleteRoom = ({ uuid }: DeleteRoom): void => fetchDelete(`/api/room/${uuid}`);

--- a/client/src/utils/apis.ts
+++ b/client/src/utils/apis.ts
@@ -34,8 +34,8 @@ interface PostRoom {
   roomType: string;
 }
 
-export const postRoom = async (body: PostRoom): Promise<HTTPResponse<RoomInfo>> => {
-  const response = await fetchPost<RoomInfo>('/api/room', { ...body });
+export const postRoom = async (body: PostRoom): Promise<HTTPResponse<{ room: RoomInfo }>> => {
+  const response = await fetchPost<{ room: RoomInfo }>('/api/room', { ...body });
   return response;
 };
 

--- a/client/tsconfig.paths.json
+++ b/client/tsconfig.paths.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
+    "baseUrl": ".",
     "paths": {
-      "@assets/*": ["assets/*"],
-      "@components/*": ["components/*"],
-      "@contexts/*": ["contexts/*"],
-      "@hooks/*": ["hooks/*"],
-      "@pages/*": ["pages/*"],
-      "@utils/*": ["utils/*"]
+      "@src/*": ["src/*"],
+      "@assets/*": ["src/assets/*"],
+      "@components/*": ["src/components/*"],
+      "@contexts/*": ["src/contexts/*"],
+      "@hooks/*": ["src/hooks/*"],
+      "@pages/*": ["src/pages/*"],
+      "@utils/*": ["src/utils/*"]
     }
   }
 }


### PR DESCRIPTION
## 개요
프론트와 서버 소켓을 연동하고 참가자 목록과 채팅 목록을 수신받도록 했습니다.
방 사이드바 탭에 적용하였으므로 이제 참가자와 채팅을 볼 수 있습니다.
그리고 몇 가지 버그를 수정했습니다.

#88 이슈와 #90 이슈, #101 이슈를 완료했습니다.

## 작업 사항
- 유저 데이터의 개발필드를 dev_field -> devField로 수정했습니다.
- 방 생성시 uuid가 보이지 않던 문제를 해결했습니다.
- 소켓을 연동하였고, 방에 입장하면 자신을 포함한 참가자 리스트를 받아옵니다.
- 방에서 채팅을 보내면 방에 참여한 참가자들에게 채팅을 전송합니다.
- 호스트가 방에서 퇴장하면 방을 삭제하는 요청을 보냅니다.

## 🧐고민고민
- 현재 호스트가 방에서 퇴장하면 방을 삭제하고 방은 메인페이지에서 사라지지만, 기존에 존재하던 유저들을 내보내지는 않습니다.
  (즉 방은 삭제되었지만, 방에 남아있던 유저들은 메인으로 나가지지 않고, 그대로 방을 이용하고 있습니다.)
  그래서 소켓 이벤트로 예를 들면 'getout' 등을 활용해서, 
  방장이 방을 나가면, getout 이벤트를 발행하고 getout 이벤트를 받은 유저(나머지 유저)들은 videoController - leaveChannel 함수를 이용해 스스로 나가도록 하는 방향으로 진행할지

  아니면 기존에 논의했던 사항 중에 랜덤으로 방장을 돌려줄 지, 
  아니면 getout 이벤트를 받은 유저는 5-4-3-2-1 등의 카운트 안내 후 자동으로 나가지도록 변경할지 고민입니다.

그외에 좋은 의견 있으시면 알려주세요!.