### PR TITLE
Hotfix: 채팅 스크롤 조정, 채팅 전송버그 수정, 화면공유버튼 버그 수정

### DIFF
--- a/client/src/components/room/tadaktadak/ChatList.tsx
+++ b/client/src/components/room/tadaktadak/ChatList.tsx
@@ -72,6 +72,7 @@ const ChatList = ({ uuid, chats, setChats }: ChatListProps<string>): JSX.Element
   const handleMessageReceive = useCallback((chat) => setChats((prevState) => [...prevState, chat]), [setChats]);
 
   useEffect(() => {
+    socket.removeListener('msgToClient');
     socket.on('msgToClient', handleMessageReceive);
   }, [handleMessageReceive]);
 

--- a/client/src/components/room/tadaktadak/ChatList.tsx
+++ b/client/src/components/room/tadaktadak/ChatList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { useUser } from '@contexts/userContext';
 import useInput from '@hooks/useInput';
@@ -6,8 +6,8 @@ import socket from '@src/socket';
 import Chat from './Chat';
 
 const INPUT_WIDTH = '90%';
-const CHAT_LIST_HEIGHT = '90%';
-const CHAT_INPUT_HEIGHT = '10%';
+const CHAT_LIST_HEIGHT = '80vh';
+const CHAT_INPUT_HEIGHT = '10vh';
 
 interface ChatListProps<T> {
   chats: Array<Record<string, T | undefined>>;
@@ -55,6 +55,7 @@ const Line = styled.div`
 const ChatList = ({ uuid, chats, setChats }: ChatListProps<string>): JSX.Element => {
   const { nickname } = useUser();
   const [message, onChangeMessage, onResetMessage] = useInput('');
+  const scrollRef = useRef<HTMLUListElement>(null);
 
   const sendMessage = useCallback(() => {
     if (!message) return;
@@ -74,9 +75,18 @@ const ChatList = ({ uuid, chats, setChats }: ChatListProps<string>): JSX.Element
     socket.on('msgToClient', handleMessageReceive);
   }, [handleMessageReceive]);
 
+  useEffect(() => {
+    const { current } = scrollRef;
+    if (current !== null) {
+      current.scrollTop = current.scrollHeight;
+    }
+  }, [chats]);
+
   return (
     <Container>
-      <List>{chats.length > 0 && Object.values(chats).map((chat, idx) => <Chat key={idx} chat={chat} />)}</List>
+      <List ref={scrollRef}>
+        {chats.length > 0 && Object.values(chats).map((chat, idx) => <Chat key={idx} chat={chat} />)}
+      </List>
       <Line />
       <InputDiv>
         <Input

--- a/client/src/components/room/tadaktadak/ScreenShareDiv.tsx
+++ b/client/src/components/room/tadaktadak/ScreenShareDiv.tsx
@@ -25,7 +25,7 @@ const ScreenShareDiv = ({
     },
     'disable',
   );
-  const { ready, tracks } = useScreenVideoTrack();
+  const { ready, tracks, error } = useScreenVideoTrack();
 
   useEffect(() => {
     const pulishScreenShare = async () => {
@@ -44,7 +44,8 @@ const ScreenShareDiv = ({
       }
     };
     if (ready) pulishScreenShare();
-  }, [setStart, setScreenShare, screenShare, client, preTracks, trackState, tracks, ready]);
+    if (error) setScreenShare(false);
+  }, [setStart, setScreenShare, screenShare, client, preTracks, trackState, tracks, ready, error]);
 
   return <div></div>;
 };


### PR DESCRIPTION
## 개요
채팅 스크롤 조정, 채팅 전송버그 수정, 화면공유버튼 버그 수정


## 작업 사항
- useRef를 이용해 채팅 컴포넌트 활성화시 채팅 스크롤을 최하단으로 자동으로 내려줍니다.

- 채팅 탭을 여러번 활성화하고 채팅을 전송시 이벤트가 중복으로 구독되어 채팅이 여러번 수신되는 문제를 개선했습니다.
     - 채팅탭 활성화 시 먼저 이벤트를 구독 취소합니다.
     - 구독 취소하고 바로 다시 이벤트를 구독해줍니다.
     - 채팅탭이 비활성화 되어 있어도, 채팅을 전송받아야 하기 때문에 다음과 같은 과정을 거치도록 했습니다.

- 화면공유버튼을 누르고 공유하지 않았을 때 버튼이 활성화 되어 있는 문제를 개선했습니다.
    - 화면공유 결과가 error를 출력하면, 버튼을 비활성화상태로 되돌려줍니다.