### PR TITLE
방 기능 설정/ 방 입장 로직 변경 / 개발분야 컨텍스트, 태그 추가

### DIFF
--- a/client/src/apis.ts
+++ b/client/src/apis.ts
@@ -78,3 +78,8 @@ export const postEnterRoom = async (uuid: string): Promise<HTTPResponse<boolean>
   const response = await fetchPost<boolean>(`/api/room/${uuid}/join`);
   return response;
 };
+
+export const postLeaveRoom = async (uuid: string): Promise<HTTPResponse<boolean>> => {
+  const response = await fetchPost<boolean>(`/api/room/${uuid}/leave`);
+  return response;
+};

--- a/client/src/apis.ts
+++ b/client/src/apis.ts
@@ -1,7 +1,6 @@
 import { UserProps } from '@contexts/userContext';
 import { RoomInfo } from '@components/main/RoomList';
 import { HTTPResponse, queryObjToString, fetchGet, fetchPost, fetchDelete } from './utils/apiUtils';
-import { DevFieldProps } from './contexts/devFieldContext';
 
 interface PostLogin {
   email: string;
@@ -85,7 +84,12 @@ export const postLeaveRoom = async (uuid: string): Promise<HTTPResponse<boolean>
   return response;
 };
 
-export const getDevField = async (): Promise<HTTPResponse<DevFieldProps[]>> => {
-  const response = await fetchGet<DevFieldProps[]>(`/api/field`);
+interface GetDevField {
+  id: string;
+  name: string;
+}
+
+export const getDevField = async (): Promise<HTTPResponse<GetDevField[]>> => {
+  const response = await fetchGet<GetDevField[]>(`/api/field`);
   return response;
 };

--- a/client/src/apis.ts
+++ b/client/src/apis.ts
@@ -1,6 +1,7 @@
 import { UserProps } from '@contexts/userContext';
 import { RoomInfo } from '@components/main/RoomList';
 import { HTTPResponse, queryObjToString, fetchGet, fetchPost, fetchDelete } from './utils/apiUtils';
+import { DevFieldProps } from './contexts/devFieldContext';
 
 interface PostLogin {
   email: string;
@@ -81,5 +82,10 @@ export const postEnterRoom = async (uuid: string): Promise<HTTPResponse<boolean>
 
 export const postLeaveRoom = async (uuid: string): Promise<HTTPResponse<boolean>> => {
   const response = await fetchPost<boolean>(`/api/room/${uuid}/leave`);
+  return response;
+};
+
+export const getDevField = async (): Promise<HTTPResponse<DevFieldProps[]>> => {
+  const response = await fetchGet<DevFieldProps[]>(`/api/field`);
   return response;
 };

--- a/client/src/apis.ts
+++ b/client/src/apis.ts
@@ -63,6 +63,11 @@ export const getRoom = async (queryObj: GetRoomQueryObj): Promise<HTTPResponse<R
   return response;
 };
 
+export const getRoomByUuid = async (uuid: string): Promise<HTTPResponse<RoomInfo>> => {
+  const response = await fetchGet<RoomInfo>(`/api/room/${uuid}`);
+  return response;
+};
+
 interface DeleteRoom {
   uuid: string;
 }

--- a/client/src/apis.ts
+++ b/client/src/apis.ts
@@ -73,3 +73,8 @@ interface DeleteRoom {
 }
 
 export const deleteRoom = ({ uuid }: DeleteRoom): void => fetchDelete(`/api/room/${uuid}`);
+
+export const postEnterRoom = async (uuid: string): Promise<HTTPResponse<boolean>> => {
+  const response = await fetchPost<boolean>(`/api/room/${uuid}/join`);
+  return response;
+};

--- a/client/src/components/JoinForm.tsx
+++ b/client/src/components/JoinForm.tsx
@@ -5,6 +5,7 @@ import { postJoin } from '@src/apis';
 import { FaGithub } from 'react-icons/fa';
 import InfoMessage from './InfoMessage';
 import Select from './common/Select';
+import { useDevField } from '@src/contexts/devFieldContext';
 
 const FORM_WIDTH = 30;
 const FORM_HEIGHT = 30;
@@ -74,11 +75,6 @@ const ModalToggleSpan = styled.span`
   }
 `;
 
-const devFieldOptions = [
-  { value: 1, label: '프론트엔드' },
-  { value: 2, label: '백엔드' },
-];
-
 interface JoinProps {
   onClickModalToggle: React.MouseEventHandler<HTMLButtonElement>;
   setIsLogin: React.Dispatch<React.SetStateAction<boolean>>;
@@ -90,6 +86,7 @@ const JoinForm = ({ onClickModalToggle, setIsLogin }: JoinProps): JSX.Element =>
   const [password, onChangePassword] = useInput('');
   const [message, setMessage] = useState('');
   const [devField, setDevField] = useState('');
+  const devFieldOptions = useDevField();
 
   const showMessage = (msg: string) => setMessage(msg);
 

--- a/client/src/components/RoomBox.tsx
+++ b/client/src/components/RoomBox.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 import { RoomInfo } from './main/RoomList';
-import { getRoomByUuid } from '@src/apis';
+import { getRoomByUuid, postEnterRoom } from '@src/apis';
 import { useHistory } from 'react-router';
 import { useCallback, useEffect, useRef } from 'react';
 import socket from '@src/socket';
@@ -112,6 +112,7 @@ const RoomBox = ({ roomInfo }: RoomBoxProps): JSX.Element => {
   }, [uuid, verifyBySocket]);
 
   const enterRoom = useCallback(() => {
+    postEnterRoom(uuid);
     history.push({ pathname: `/room/${uuid}`, state: roomDataRef.current });
   }, [history, uuid, roomDataRef]);
 

--- a/client/src/components/RoomBox.tsx
+++ b/client/src/components/RoomBox.tsx
@@ -1,11 +1,13 @@
-import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { RoomInfo } from './main/RoomList';
+import { getRoomByUuid } from '@src/apis';
+import { useHistory } from 'react-router';
+import { useCallback } from 'react';
 
 const ROOM_WIDTH = 20;
 const ROOM_HEIGHT = ROOM_WIDTH * 0.75;
 
-const RoomLink = styled(Link)`
+const RoomBoxWrapper = styled.div`
   ${({ theme }) => theme.flexCenter};
   flex-direction: column;
   background-color: ${({ theme }) => theme.colors.white};
@@ -92,8 +94,19 @@ interface RoomBoxProps {
 
 const RoomBox = ({ roomInfo }: RoomBoxProps): JSX.Element => {
   const { uuid, title, description, nowHeadcount, maxHeadcount } = roomInfo;
+  const history = useHistory();
+
+  const onClickRoomBox = useCallback(async () => {
+    const { isOk, data } = await getRoomByUuid(uuid);
+    if (isOk && data) {
+      if (data.nowHeadcount < data.maxHeadcount) {
+        history.push({ pathname: `/room/${uuid}`, state: data });
+      }
+    }
+  }, [history, uuid]);
+
   return (
-    <RoomLink to={{ pathname: `/room/${uuid}`, state: roomInfo }}>
+    <RoomBoxWrapper onClick={onClickRoomBox}>
       <RoomBoxTop>
         <RoomTitle>{title}</RoomTitle>
         <RoomDescription>{description}</RoomDescription>
@@ -104,7 +117,7 @@ const RoomBox = ({ roomInfo }: RoomBoxProps): JSX.Element => {
           {nowHeadcount} / {maxHeadcount}
         </RoomAdmitNumber>
       </RoomBoxBottom>
-    </RoomLink>
+    </RoomBoxWrapper>
   );
 };
 

--- a/client/src/components/main/SideBar.tsx
+++ b/client/src/components/main/SideBar.tsx
@@ -1,12 +1,13 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import LoginModal from '../LoginModal';
 import { useUser, useUserFns } from '@contexts/userContext';
 import { IoLogOutOutline } from 'react-icons/io5';
 import Modal from '@components/common/Modal';
 import CreateForm from './CreateForm';
-import { postLogout } from '@src/apis';
+import { getDevField, postLogout } from '@src/apis';
 import { FieldName } from '@src/contexts/userContext';
+import { useDevFieldFns } from '@src/contexts/devFieldContext';
 
 const SIDEBAR_MIN_WIDTH = '29rem';
 
@@ -125,6 +126,7 @@ const SideBar = (): JSX.Element => {
   const [createModal, setCreateModal] = useState(false);
   const user = useUser();
   const { logUserOut } = useUserFns();
+  const { registerDevField } = useDevFieldFns();
 
   const onClickLoginBtn = () => setLoginModal(!loginModal);
   const onClickCreateBtn = () => setCreateModal(true);
@@ -135,6 +137,16 @@ const SideBar = (): JSX.Element => {
       logUserOut();
     }
   };
+
+  useEffect(() => {
+    async function initDevField() {
+      const { isOk, data } = await getDevField();
+      if (isOk && data) {
+        registerDevField(data);
+      }
+    }
+    initDevField();
+  }, [registerDevField]);
 
   return (
     <SideBarContainer>

--- a/client/src/components/main/SideBar.tsx
+++ b/client/src/components/main/SideBar.tsx
@@ -142,7 +142,14 @@ const SideBar = (): JSX.Element => {
     async function initDevField() {
       const { isOk, data } = await getDevField();
       if (isOk && data) {
-        registerDevField(data);
+        const changeToSelectData = data.map((obj) => {
+          const newObj = {
+            value: obj.id,
+            label: obj.name,
+          };
+          return newObj;
+        });
+        registerDevField(changeToSelectData);
       }
     }
     initDevField();

--- a/client/src/components/main/SideBar.tsx
+++ b/client/src/components/main/SideBar.tsx
@@ -6,6 +6,7 @@ import { IoLogOutOutline } from 'react-icons/io5';
 import Modal from '@components/common/Modal';
 import CreateForm from './CreateForm';
 import { postLogout } from '@src/apis';
+import { FieldName } from '@src/contexts/userContext';
 
 const SIDEBAR_MIN_WIDTH = '29rem';
 
@@ -110,6 +111,15 @@ const UserAvatar = styled.img`
 
 const UserNickname = styled.span``;
 
+const UserDevField = styled.div<{ bgColor: FieldName }>`
+  ${({ theme, bgColor }) => css`
+    margin-left: ${theme.margins.base};
+    background-color: ${theme.tagColors[bgColor]};
+    padding: ${theme.paddings.xs};
+    border-radius: ${theme.borderRadius.sm};
+  `}
+`;
+
 const SideBar = (): JSX.Element => {
   const [loginModal, setLoginModal] = useState(false);
   const [createModal, setCreateModal] = useState(false);
@@ -134,6 +144,7 @@ const SideBar = (): JSX.Element => {
             <UserInfoDiv onClick={onClickUserInfoBtn}>
               <UserAvatar src={user.imageUrl}></UserAvatar>
               <UserNickname>{user.nickname}</UserNickname>
+              <UserDevField bgColor={user?.devField?.name ?? 'None'}>{user?.devField?.name}</UserDevField>
             </UserInfoDiv>
             <LogoutBtn onClick={onClickLogoutBtn}>
               <span>로그아웃</span>

--- a/client/src/components/room/tadaktadak/ParticipantList.tsx
+++ b/client/src/components/room/tadaktadak/ParticipantList.tsx
@@ -1,8 +1,11 @@
-import styled from 'styled-components';
+import { useContext } from 'react';
+import styled, { css, ThemeContext } from 'styled-components';
 
 interface ParticipantListProps<T> {
   participants: Record<string, T>;
 }
+
+type FieldName = 'Front-end' | 'Back-end' | 'IOS' | 'Android';
 
 const Container = styled.div`
   width: 100%;
@@ -36,11 +39,20 @@ const Nickname = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.lg};
 `;
 
-const DevField = styled.div``;
+const DevField = styled.div<{ bgColor: string }>`
+  background-color: ${({ bgColor }) => bgColor};
+  ${({ theme }) => css`
+    margin-left: ${theme.margins.base};
+    padding: ${theme.paddings.sm};
+    border-radius: ${theme.borderRadius.sm};
+  `}
+`;
 
 const ParticipantList = ({
   participants,
-}: ParticipantListProps<{ field: { id: number; name: string }; img: string }>): JSX.Element => {
+}: ParticipantListProps<{ field: { id: number; name: FieldName }; img: string }>): JSX.Element => {
+  const themeContext = useContext(ThemeContext);
+
   return (
     <Container>
       <List>
@@ -48,7 +60,7 @@ const ParticipantList = ({
           <Participant key={nickname}>
             <Avatar src={img} />
             <Nickname>{nickname}</Nickname>
-            {field && <DevField>{field.name}</DevField>}
+            {field && <DevField bgColor={themeContext.tagColors[field.name]}>{field.name}</DevField>}
           </Participant>
         ))}
       </List>

--- a/client/src/components/room/tadaktadak/ParticipantList.tsx
+++ b/client/src/components/room/tadaktadak/ParticipantList.tsx
@@ -38,7 +38,9 @@ const Nickname = styled.span`
 
 const DevField = styled.div``;
 
-const ParticipantList = ({ participants }: ParticipantListProps<{ field: string; img: string }>): JSX.Element => {
+const ParticipantList = ({
+  participants,
+}: ParticipantListProps<{ field: { id: number; name: string }; img: string }>): JSX.Element => {
   return (
     <Container>
       <List>
@@ -46,7 +48,7 @@ const ParticipantList = ({ participants }: ParticipantListProps<{ field: string;
           <Participant key={nickname}>
             <Avatar src={img} />
             <Nickname>{nickname}</Nickname>
-            {field && <DevField>{field}</DevField>}
+            {field && <DevField>{field.name}</DevField>}
           </Participant>
         ))}
       </List>

--- a/client/src/components/room/tadaktadak/ParticipantList.tsx
+++ b/client/src/components/room/tadaktadak/ParticipantList.tsx
@@ -1,11 +1,10 @@
 import { useContext } from 'react';
 import styled, { css, ThemeContext } from 'styled-components';
+import { FieldName } from '@src/contexts/userContext';
 
 interface ParticipantListProps<T> {
   participants: Record<string, T>;
 }
-
-type FieldName = 'Front-end' | 'Back-end' | 'IOS' | 'Android';
 
 const Container = styled.div`
   width: 100%;

--- a/client/src/components/room/tadaktadak/RoomSideBar.tsx
+++ b/client/src/components/room/tadaktadak/RoomSideBar.tsx
@@ -5,6 +5,7 @@ import ChatList from './ChatList';
 import ParticipantList from './ParticipantList';
 import { useUser } from '@contexts/userContext';
 import socket from '@src/socket';
+import { postLeaveRoom } from '@src/apis';
 
 const SIDEBAR_MIN_WIDTH = '29rem';
 const SIDEBAR_HEIGHT = '100vh';
@@ -58,6 +59,7 @@ const RoomSideBar = ({ uuid }: RoomSideBarProps): JSX.Element => {
   const leaveSocket = useCallback(() => {
     const leavePayload = { nickname, roomId: uuid };
     socket.emit('leave-room', leavePayload);
+    postLeaveRoom(uuid);
   }, [nickname, uuid]);
 
   useEffect(() => {

--- a/client/src/contexts/devFieldContext.tsx
+++ b/client/src/contexts/devFieldContext.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useContext, useState } from 'react';
 
 export interface DevFieldProps {
-  id: string;
-  name: string;
+  label: string;
+  value: string;
 }
 
 export interface DevFieldFnProps {

--- a/client/src/contexts/devFieldContext.tsx
+++ b/client/src/contexts/devFieldContext.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback, useContext, useState } from 'react';
+
+export interface DevFieldProps {
+  id: string;
+  name: string;
+}
+
+export interface DevFieldFnProps {
+  registerDevField: (newDevField: DevFieldProps[]) => void;
+}
+
+interface DevFieldContextProps {
+  devField: DevFieldProps[];
+  fn: DevFieldFnProps;
+}
+
+const DevFieldContext = React.createContext<DevFieldContextProps>({
+  devField: [],
+  fn: {
+    registerDevField: () => {},
+  },
+});
+
+const DevFieldContextProvider = ({ children }: { children: React.ReactNode }): JSX.Element => {
+  const [devField, setDevField] = useState<DevFieldProps[]>([]);
+  const registerDevField = useCallback((newDevField: DevFieldProps[]) => setDevField([...newDevField]), []);
+
+  return <DevFieldContext.Provider value={{ devField, fn: { registerDevField } }}>{children}</DevFieldContext.Provider>;
+};
+
+export const useDevField = (): DevFieldProps[] => {
+  const { devField } = useContext(DevFieldContext);
+  return devField;
+};
+
+export const useDevFieldFns = (): DevFieldFnProps => {
+  const { fn } = useContext(DevFieldContext);
+  return fn;
+};
+
+export default DevFieldContextProvider;

--- a/client/src/contexts/userContext.tsx
+++ b/client/src/contexts/userContext.tsx
@@ -1,5 +1,7 @@
 import React, { useContext, useState } from 'react';
 
+export type FieldName = 'Front-end' | 'Back-end' | 'IOS' | 'Android' | 'None';
+
 export interface UserProps {
   id?: number;
   nickname?: string;
@@ -9,7 +11,7 @@ export interface UserProps {
   isSocial?: boolean;
   devField?: {
     id: number;
-    name: string;
+    name: FieldName;
   };
   login?: boolean;
 }

--- a/client/src/pages/Main/Main.tsx
+++ b/client/src/pages/Main/Main.tsx
@@ -3,11 +3,14 @@ import { MainWrapper, MainContainer } from './style';
 import SideBar from '@components/main/SideBar';
 import RoomList from '@components/main/RoomList';
 import ServiceInfo from '@components/main/ServiceInfo';
+import DevFieldContextProvider from '@src/contexts/devFieldContext';
 
 const Main = (): JSX.Element => {
   return (
     <MainWrapper>
-      <SideBar />
+      <DevFieldContextProvider>
+        <SideBar />
+      </DevFieldContextProvider>
       <MainContainer>
         <ServiceInfo />
         <RoomList />

--- a/client/src/styles/styled.d.ts
+++ b/client/src/styles/styled.d.ts
@@ -16,6 +16,7 @@ interface BtnSizes {
 }
 
 interface Sizes {
+  xs?: string;
   sm: string;
   base: string;
   lg: string;
@@ -43,6 +44,7 @@ interface TagColors {
   'Back-end': string;
   IOS: string;
   Android: string;
+  None: string;
 }
 
 declare module 'styled-components' {

--- a/client/src/styles/styled.d.ts
+++ b/client/src/styles/styled.d.ts
@@ -38,6 +38,13 @@ interface Colors {
   green: string;
 }
 
+interface TagColors {
+  'Front-end': string;
+  'Back-end': string;
+  IOS: string;
+  Android: string;
+}
+
 declare module 'styled-components' {
   export interface DefaultTheme {
     borderRadius: BorderRadius;
@@ -55,5 +62,6 @@ declare module 'styled-components' {
     flexColumn: string;
     active: string;
     transition: string;
+    tagColors: TagColors;
   }
 }

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -27,6 +27,12 @@ const theme: DefaultTheme = {
     borderGrey: '#D8DEE3',
     green: '#339933',
   },
+  tagColors: {
+    'Front-end': '#9EEDEF',
+    'Back-end': '#F5F5D5',
+    IOS: '#FFE4E5',
+    Android: '#8685EF',
+  },
   margins: {
     sm: '0.5rem',
     base: '1.0rem',

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -32,14 +32,17 @@ const theme: DefaultTheme = {
     'Back-end': '#F5F5D5',
     IOS: '#FFE4E5',
     Android: '#8685EF',
+    None: '#908989',
   },
   margins: {
+    xs: '0.3rem',
     sm: '0.5rem',
     base: '1.0rem',
     lg: '2.0rem',
     xl: '3.0rem',
   },
   paddings: {
+    xs: '0.3rem',
     sm: '.5rem',
     base: '1.0rem',
     lg: '2.0rem',


### PR DESCRIPTION
## 개요
몇 개의 방 기능을 추가하고, 개발 태그를 추가했습니다. 
방 입장 로직을 변경했습니다.
참가자 리스트 버그를 수정했습니다.
개발분야 컨텍스트를 추가했습니다.

## 작업 사항
- 비디오를 더블클릭하면 전체화면이 되는 기능을 추가했습니다.
- 참가자 리스트를 클릭할 때 화면이 멈추던 버그를 수정했습니다.
- 참가자 리스트와 메인 사이드바에 개발 필드 태그를 추가하고, 색상을 부여했습니다.
- 방 입장 로직을 변경했습니다.
  - 로직은 다음과 같습니다.
  - uuid 기반 방 정보 요청 -> 응답 데이터 필드기반 입장가능여부 확인 -> 소켓기반 입장가능여부 확인 -> 방 인원 증가 -> 입장
- 개발분야 컨텍스트를 추가했습니다.
  - 이 컨텍스트는, 회원가입 모달과 사용자정보페이지에서 사용할 예정입니다.
  - 회원가입 모달에 개발분야 컨텍스트의 데이터를 추가했습니다.

## 🧐고민고민
- 한별님과 오전에 고민했던 내용인데, 비디오 전체화면을 화면공유시에만 가능하도록 하고 싶은데 캠 스트림과 화면공유 스트림을 구분할만한 확실한 키가 없어서 고민이네요.