### PR TITLE
회원 정보 페이지 스켈레톤

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import Main from '@pages/Main';
 import { useUser, useUserFns } from '@contexts/userContext';
 import { getUserByToken } from '@src/apis';
 import Room from '@pages/Room';
+import Profile from '@pages/Profile';
 
 const App = (): JSX.Element => {
   const user = useUser();
@@ -32,6 +33,7 @@ const App = (): JSX.Element => {
           <Route exact path="/" component={Introduction} />
           <Route path="/main" component={Main} />
           <Route path="/room" component={Room} />
+          <Route path="/profile" component={Profile} />
           <Redirect from="*" to="/" />
         </Switch>
       </BrowserRouter>

--- a/client/src/apis.ts
+++ b/client/src/apis.ts
@@ -1,6 +1,6 @@
 import { UserProps } from '@contexts/userContext';
 import { RoomInfo } from '@components/main/RoomList';
-import { HTTPResponse, queryObjToString, fetchGet, fetchPost, fetchDelete } from './utils/apiUtils';
+import { HTTPResponse, queryObjToString, fetchGet, fetchPost, fetchPatch, fetchDelete } from './utils/apiUtils';
 
 interface PostLogin {
   email: string;
@@ -23,6 +23,17 @@ interface PostJoin extends PostLogin {
 
 export const postJoin = async (body: PostJoin): Promise<HTTPResponse<boolean>> => {
   const response = await fetchPost<boolean>('/api/auth/join', { ...body });
+  return response;
+};
+
+interface PatchUpdate {
+  originalName: string;
+  nickname: string;
+  devField?: number;
+}
+
+export const patchUpdate = async (body: PatchUpdate): Promise<HTTPResponse<UserProps>> => {
+  const response = await fetchPatch<UserProps>(`/api/user/${body.originalName}`, { ...body });
   return response;
 };
 

--- a/client/src/components/main/SideBar.tsx
+++ b/client/src/components/main/SideBar.tsx
@@ -6,6 +6,7 @@ import { IoLogOutOutline } from 'react-icons/io5';
 import Modal from '@components/common/Modal';
 import CreateForm from './CreateForm';
 import { postLogout } from '@src/apis';
+import { useHistory } from 'react-router-dom';
 
 const SIDEBAR_MIN_WIDTH = '29rem';
 
@@ -115,14 +116,18 @@ const SideBar = (): JSX.Element => {
   const [createModal, setCreateModal] = useState(false);
   const user = useUser();
   const { logUserOut } = useUserFns();
+  const history = useHistory();
 
   const onClickLoginBtn = () => setLoginModal(!loginModal);
   const onClickCreateBtn = () => setCreateModal(true);
-  const onClickUserInfoBtn = () => {};
+  const onClickUserInfoBtn = () => {
+    history.push(`/profile`);
+  };
   const onClickLogoutBtn = async () => {
     const { isOk } = await postLogout();
     if (isOk) {
       logUserOut();
+      if (history.location.pathname !== '/') location.href = '/main';
     }
   };
 

--- a/client/src/components/profile/InfoForm.tsx
+++ b/client/src/components/profile/InfoForm.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { useUser } from '@contexts/userContext';
+
+interface InfoProps {
+  onClickModifyToggle: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const InfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 3px;
+`;
+const Legend = styled.legend`
+  font-size: 3rem;
+  color: ${({ theme }) => theme.colors.bgGreen};
+`;
+
+const Info = styled.div`
+  font-size: 7rem;
+  color: ${({ theme }) => theme.colors.bgGreen};
+`;
+
+const InfoSet = styled.fieldset`
+  ${({ theme }) => css`
+    background-color: ${theme.colors.grey};
+    padding: ${theme.paddings.lg};
+    border: 1px solid ${theme.colors.borderGrey};
+    border-radius: ${theme.borderRadius.base};
+  `};
+`;
+
+const ModalToggleSpan = styled.span`
+  ${({ theme }) => theme.flexCenter}
+  background-color: ${({ theme }) => theme.colors.green};
+  padding: ${({ theme }) => theme.paddings.sm};
+  color: ${({ theme }) => theme.colors.white};
+  border-radius: 1rem;
+  cursor: pointer;
+  :hover {
+    color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+const InfoForm = ({ onClickModifyToggle }: InfoProps): JSX.Element => {
+  const user = useUser();
+  console.log(user);
+  return (
+    <Wrapper>
+      <InfoWrapper>
+        <InfoSet>
+          <Legend>{`이메일`}</Legend>
+          <Info>{user.email}</Info>
+        </InfoSet>
+        <InfoSet>
+          <Legend>{`닉네임`}</Legend>
+          <Info>{user.nickname}</Info>
+        </InfoSet>
+
+        <InfoSet>
+          <Legend>{`관심 분야`}</Legend>
+          <Info>{user.devField?.name}</Info>
+        </InfoSet>
+      </InfoWrapper>
+      <ModalToggleSpan onClick={onClickModifyToggle}>수정하기</ModalToggleSpan>
+    </Wrapper>
+  );
+};
+
+export default InfoForm;

--- a/client/src/components/profile/InfoForm.tsx
+++ b/client/src/components/profile/InfoForm.tsx
@@ -49,7 +49,6 @@ const ModalToggleSpan = styled.span`
 
 const InfoForm = ({ onClickModifyToggle }: InfoProps): JSX.Element => {
   const user = useUser();
-  console.log(user);
   return (
     <Wrapper>
       <InfoWrapper>

--- a/client/src/components/profile/ModifyForm.tsx
+++ b/client/src/components/profile/ModifyForm.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import styled, { css } from 'styled-components';
+import { useUser, useUserFns } from '@contexts/userContext';
+import Select from '../common/Select';
+import useInput from '@src/hooks/useInput';
+import { patchUpdate } from '@src/apis';
+
+interface InfoProps {
+  onClickModifyToggle: React.MouseEventHandler<HTMLButtonElement>;
+  setIsModify: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const InfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 3px;
+`;
+const Legend = styled.legend`
+  font-size: 3rem;
+  color: ${({ theme }) => theme.colors.bgGreen};
+`;
+
+const Info = styled.div`
+  font-size: 7rem;
+  color: ${({ theme }) => theme.colors.bgGreen};
+`;
+
+const InfoSet = styled.fieldset`
+  ${({ theme }) => css`
+    background-color: ${theme.colors.grey};
+    padding: ${theme.paddings.lg};
+    border: 1px solid ${theme.colors.borderGrey};
+    border-radius: ${theme.borderRadius.base};
+  `};
+`;
+
+const ModifySpan = styled.span`
+  ${({ theme }) => theme.flexCenter}
+  width:100%;
+  background-color: ${({ theme }) => theme.colors.green};
+  padding: ${({ theme }) => theme.paddings.sm};
+  color: ${({ theme }) => theme.colors.white};
+  border-radius: 1rem;
+  cursor: pointer;
+  :hover {
+    color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+const CancelSpan = styled.span`
+  ${({ theme }) => theme.flexCenter}
+  width:100%;
+  background-color: ${({ theme }) => theme.colors.secondary};
+  padding: ${({ theme }) => theme.paddings.sm};
+  color: ${({ theme }) => theme.colors.white};
+  border-radius: 1rem;
+  cursor: pointer;
+  :hover {
+    color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+const Input = styled.input`
+  font-size: 40px;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+const devFieldOptions = [
+  { value: 1, label: '프론트엔드' },
+  { value: 2, label: '백엔드' },
+];
+
+const ModifyForm = ({ onClickModifyToggle, setIsModify }: InfoProps): JSX.Element => {
+  const user = useUser();
+  const { logUserIn } = useUserFns();
+  const [nickname, onChangeNickname] = useInput(user.nickname ?? '정보 오류');
+  const [devField, setDevField] = useState(user.devField?.id);
+  const handleDevFieldSelectChange = (e: React.ChangeEvent<HTMLSelectElement>): void =>
+    setDevField(+(e.target[e.target.selectedIndex] as HTMLOptionElement).value);
+
+  const onSubmit = async () => {
+    if (nickname === user.nickname && user.devField?.id === devField) {
+      setIsModify(false);
+      return;
+    }
+
+    const originalName = user.nickname ?? '';
+    const requestBody = { originalName, nickname, devField: devField === 0 ? user.devField?.id : devField };
+
+    const { data } = await patchUpdate(requestBody);
+    if (data) {
+      logUserIn(data);
+      setIsModify(false);
+    }
+  };
+  return (
+    <Wrapper>
+      <InfoWrapper>
+        <InfoSet>
+          <Legend>{`이메일`}</Legend>
+          <Info>{user.email}</Info>
+        </InfoSet>
+        <InfoSet>
+          <Legend>{`닉네임`}</Legend>
+          <Input type="text" value={nickname} onChange={onChangeNickname}></Input>
+        </InfoSet>
+
+        <InfoSet>
+          <Legend>{`관심 분야`}</Legend>
+          <Select name={'개발 필드'} options={devFieldOptions} onChange={handleDevFieldSelectChange} />
+        </InfoSet>
+      </InfoWrapper>
+      <ButtonWrapper>
+        <ModifySpan onClick={onSubmit}>수정하기</ModifySpan>
+        <CancelSpan onClick={onClickModifyToggle}>취소</CancelSpan>
+      </ButtonWrapper>
+    </Wrapper>
+  );
+};
+
+export default ModifyForm;

--- a/client/src/components/profile/UserInfo.tsx
+++ b/client/src/components/profile/UserInfo.tsx
@@ -1,0 +1,98 @@
+import styled, { css } from 'styled-components';
+import { useState } from 'react';
+import InfoForm from './InfoForm';
+import { useUser } from '@contexts/userContext';
+import ModifyForm from './ModifyForm';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+
+  ${({ theme }) => css`
+    background-color: ${theme.colors.grey};
+    padding: ${theme.paddings.lg};
+    border: 1px solid ${theme.colors.borderGrey};
+    border-radius: ${theme.borderRadius.base};
+  `};
+`;
+
+const UserAvatar = styled.img`
+  margin-right: ${({ theme }) => theme.margins.base};
+
+  width: 30rem;
+  height: 30rem;
+  border-radius: 50%;
+  overflow: hidden;
+`;
+
+const ImageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+const MainTitle = styled.h1`
+  font-size: 10rem;
+  color: ${({ theme }) => theme.colors.bgGreen};
+`;
+
+const UploadSpan = styled.label`
+  ${({ theme }) => theme.flexCenter}
+  width:100%;
+  background-color: ${({ theme }) => theme.colors.green};
+  margin-top: ${({ theme }) => theme.margins.sm};
+  padding: ${({ theme }) => theme.paddings.sm};
+  color: ${({ theme }) => theme.colors.white};
+  border-radius: 1rem;
+  cursor: pointer;
+  :hover {
+    color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+const DeleteSpan = styled.span`
+  ${({ theme }) => theme.flexCenter}
+  width:100%;
+  background-color: ${({ theme }) => theme.colors.secondary};
+  margin-top: ${({ theme }) => theme.margins.sm};
+  padding: ${({ theme }) => theme.paddings.sm};
+  color: ${({ theme }) => theme.colors.white};
+  border-radius: 1rem;
+  cursor: pointer;
+  :hover {
+    color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+function UserInfo(): JSX.Element {
+  const [isModify, setIsModify] = useState(false);
+  const onClickModifyToggle = () => setIsModify(!isModify);
+  const user = useUser();
+
+  return (
+    <div>
+      <MainTitle>마이 프로필</MainTitle>
+      <Wrapper>
+        {isModify ? (
+          <ModifyForm onClickModifyToggle={onClickModifyToggle} setIsModify={setIsModify} />
+        ) : (
+          <InfoForm onClickModifyToggle={onClickModifyToggle} />
+        )}
+        <ImageWrapper>
+          <UserAvatar src={user.imageUrl}></UserAvatar>
+          <ButtonWrapper>
+            <UploadSpan htmlFor="upload">업로드</UploadSpan>
+            <input type="file" id="upload" style={{ display: 'none' }}></input>
+            <DeleteSpan>삭제</DeleteSpan>
+          </ButtonWrapper>
+        </ImageWrapper>
+      </Wrapper>
+    </div>
+  );
+}
+
+export default UserInfo;

--- a/client/src/components/profile/UserInfo.tsx
+++ b/client/src/components/profile/UserInfo.tsx
@@ -1,8 +1,9 @@
 import styled, { css } from 'styled-components';
 import { useState } from 'react';
 import InfoForm from './InfoForm';
-import { useUser } from '@contexts/userContext';
+import { useUser, useUserFns } from '@contexts/userContext';
 import ModifyForm from './ModifyForm';
+import axios from 'axios';
 
 const Wrapper = styled.div`
   display: flex;
@@ -72,6 +73,25 @@ function UserInfo(): JSX.Element {
   const [isModify, setIsModify] = useState(false);
   const onClickModifyToggle = () => setIsModify(!isModify);
   const user = useUser();
+  const { logUserIn } = useUserFns();
+
+  const handleFileInput = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    // eslint-disable-next-line
+    const fileList = e.target.files;
+
+    if (!fileList) return;
+    const formData = new FormData();
+    // eslint-disable-next-line
+
+    formData.append('image', fileList[0]);
+    const { data } = await axios.post(`/api/user/image`, formData, {
+      withCredentials: true,
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+    if (data) {
+      logUserIn(data);
+    }
+  };
 
   return (
     <div>
@@ -86,7 +106,7 @@ function UserInfo(): JSX.Element {
           <UserAvatar src={user.imageUrl}></UserAvatar>
           <ButtonWrapper>
             <UploadSpan htmlFor="upload">업로드</UploadSpan>
-            <input type="file" id="upload" style={{ display: 'none' }}></input>
+            <input type="file" onChange={handleFileInput} id="upload" style={{ display: 'none' }}></input>
             <DeleteSpan>삭제</DeleteSpan>
           </ButtonWrapper>
         </ImageWrapper>

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -1,0 +1,14 @@
+import { ProfileWrapper, ProfileContainer } from './style';
+import SideBar from '@components/main/SideBar';
+import UserInfo from '@components/profile/UserInfo';
+const Profile = (): JSX.Element => {
+  return (
+    <ProfileWrapper>
+      <SideBar />
+      <ProfileContainer>
+        <UserInfo />
+      </ProfileContainer>
+    </ProfileWrapper>
+  );
+};
+export default Profile;

--- a/client/src/pages/Profile/index.ts
+++ b/client/src/pages/Profile/index.ts
@@ -1,0 +1,3 @@
+import Profile from './Profile';
+
+export default Profile;

--- a/client/src/pages/Profile/style.ts
+++ b/client/src/pages/Profile/style.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const ProfileWrapper = styled.div`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+`;
+
+export const ProfileContainer = styled.div`
+  padding: ${({ theme }) => theme.paddings.xl};
+  width: 100%;
+  height: 100%;
+`;

--- a/client/src/utils/apiUtils.ts
+++ b/client/src/utils/apiUtils.ts
@@ -53,6 +53,20 @@ function postOptions(body: BodyType): RequestInit {
     : simpleOptions('POST');
 }
 
+function patchOptions(body: BodyType): RequestInit {
+  return Object.keys(body).length
+    ? {
+        method: 'PATCH',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify(body),
+      }
+    : simpleOptions('PATCH');
+}
+
 function deleteOptions(): RequestInit {
   return simpleOptions('DELETE');
 }
@@ -93,6 +107,12 @@ export async function fetchGet<T>(url: string, query?: string): Promise<HTTPResp
 export async function fetchPost<T>(url: string, body: BodyType = {}): Promise<HTTPResponse<T>> {
   const requestUrl = getUrl(url);
   const response = await fetcher<T>(requestUrl, postOptions(body));
+  return response;
+}
+
+export async function fetchPatch<T>(url: string, body: BodyType = {}): Promise<HTTPResponse<T>> {
+  const requestUrl = getUrl(url);
+  const response = await fetcher<T>(requestUrl, patchOptions(body));
   return response;
 }
 

--- a/server/api/src/domain/field/controller/dev-field.controller.ts
+++ b/server/api/src/domain/field/controller/dev-field.controller.ts
@@ -1,6 +1,5 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { JwtAuthGuard } from '../../auth/guard/jwt-auth-guard';
 import { DevFieldRepository } from '../repository/dev-field.repository';
 
 @Controller('field')
@@ -11,8 +10,7 @@ export class DevFieldController {
   ) {}
 
   @Get()
-  @UseGuards(JwtAuthGuard)
-  async getUserInfo() {
+  async getDevInfo() {
     return { result: await this.devFieldRepository.find() };
   }
 }

--- a/server/api/src/domain/history/service/history.service.ts
+++ b/server/api/src/domain/history/service/history.service.ts
@@ -29,6 +29,6 @@ export class HistoryService {
 
   async getLastVisitCount() {
     const visitCount = await this.visitRepository.getVisitCount();
-    return visitCount ? visitCount.totalVisit : 0;
+    return visitCount.totalVisit ?? 0;
   }
 }

--- a/server/api/src/domain/user/controller/user.controller.ts
+++ b/server/api/src/domain/user/controller/user.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Req,
   Delete,
   Get,
   Param,
@@ -10,6 +11,7 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../../auth/guard/jwt-auth-guard';
 import { UserService } from '../service/user.service';
@@ -38,11 +40,11 @@ export class UserController {
     return { result: await this.historyService.getHistory(nickname) };
   }
 
-  @Post('/:userId/image')
+  @Post('/image')
   @UseGuards(JwtAuthGuard)
   @UseInterceptors(FileInterceptor('image'))
-  async uploadUserImage(@Param('userId') nickname: string, @UploadedFile() file: Express.Multer.File) {
-    return { result: await this.userService.updateImage(nickname, file) };
+  async uploadUserImage(@Req() req: Request, @UploadedFile() file: Express.Multer.File) {
+    return { result: await this.userService.updateImage(req.user['email'], file) };
   }
 
   @Patch('/:userId/image')

--- a/server/api/src/domain/user/dto/user-update.dto.ts
+++ b/server/api/src/domain/user/dto/user-update.dto.ts
@@ -4,11 +4,5 @@ export class UserUpdateDto {
   readonly nickname: string;
 
   @IsNotEmpty()
-  readonly password: string;
-
-  @IsNotEmpty()
   readonly devField: number;
-
-  @IsNotEmpty()
-  readonly introduction: string;
 }

--- a/server/api/src/domain/user/service/user.service.ts
+++ b/server/api/src/domain/user/service/user.service.ts
@@ -28,14 +28,17 @@ export class UserService {
   async updateUserInfo(nickname: string, userUpdateDto: UserUpdateDto) {
     const updateUser: User = await this.authRepository.findUserByNickname(nickname);
     if (!updateUser) throw UserException.userNotFound();
+    const sameNickname: boolean = nickname === userUpdateDto.nickname;
+    if (!sameNickname) {
+      const existUser: User = await this.authRepository.findUserByNickname(userUpdateDto.nickname);
+      if (existUser) throw UserException.userIsExist();
+    }
     const newDevField: DevField = await this.devFieldRepository.findDevById(userUpdateDto.devField);
     if (!newDevField) throw DevFieldException.devFieldNotFound();
     updateUser.setNickname(userUpdateDto.nickname);
-    updateUser.setPassword(userUpdateDto.password);
-    updateUser.setIntroduction(userUpdateDto.introduction);
     updateUser.setDevField(newDevField);
     await this.authRepository.save(updateUser);
-    return true;
+    return new UserResponseDto(updateUser);
   }
 
   async updateImage(nickname: string, file) {

--- a/server/api/src/domain/user/service/user.service.ts
+++ b/server/api/src/domain/user/service/user.service.ts
@@ -38,18 +38,20 @@ export class UserService {
     updateUser.setNickname(userUpdateDto.nickname);
     updateUser.setDevField(newDevField);
     await this.authRepository.save(updateUser);
+    //빌더 적용하기
     return new UserResponseDto(updateUser);
   }
 
-  async updateImage(nickname: string, file) {
-    const updateUser: User = await this.authRepository.findUserByNickname(nickname);
+  async updateImage(email: string, file) {
+    const updateUser: User = await this.authRepository.findUserByUserEmail(email);
     if (!updateUser) throw UserException.userNotFound();
     if (updateUser.imageName) await this.imageService.deleteImage(updateUser.imageName);
     const imageInfo = await this.imageService.uploadImage(file);
     updateUser.setImageUrl(imageInfo.Location);
     updateUser.setImageName(imageInfo.key);
     await this.authRepository.save(updateUser);
-    return updateUser.imageUrl;
+    //빌더 적용 하기
+    return new UserResponseDto(updateUser);
   }
 
   async deleteImage(nickname: string) {


### PR DESCRIPTION
## 개요
![image](https://user-images.githubusercontent.com/51132077/142931774-d1414a07-4bb0-4c7d-a146-1d2b8fb071e4.png)
![image](https://user-images.githubusercontent.com/51132077/142932078-ec02d01c-e8a2-433b-9b00-20379b9add6b.png)

움짤 녹화하는 법을 몰라서 캡쳐로 첨부합니다.
회원 정보 페이지 틀만 완성했습니다. 
회원 정보 업데이트 API와 아바타 변경 API만 연동 했습니다.
구현하면서 어느 정도 감잡아싿고 생각했는데 상태관리(?) 이 쪽에서 계속 빈 틈이 생겨 엉망이군요 ㅎㅎ...


## 작업 사항
- 회원 정보 페이지 틀
- 회원 정보 업데이트 API 연동
- 아바타 변경 API 연동

## 🧐고민고민
- 아무 많네요.. 컴포넌트 이름도 엉망이고.. 콘솔만 보고 있을 때가 벌써 그립네요... 그래도 뭔가 만드니까 뿌듯하네요 ㅎㅎ
- 리액트에 대한 흥미가 5만큼 증가한 거 같습니다.
- UI는 이리 저리 왔다 갔다 하며 해봤는데 나타낼 정보가 많지도 않고, 공간은 넓으니 이쁘질 않군여...
- 회원 정보 수정이나, 아바타가 변경되면 사이드바에 있는 버튼도 다시 렌더링 되어야 하는데 어떤 식으로 해야 되는지 도와주세요!
- 이미지를 중간으로 옮기고, 업로드와 삭제 버튼을 왼쪽 수정하기 버튼과 일직선 상으로 놓고 싶은데 어떻게 해야할까요...
- 컴포넌트가 변경돼도 다른 컴포넌트들이 자기 자리를 유지했으면 좋겠는데 계속 움직이는데 고정 시킬 방법이 있나요
