### PR TITLE
추방 기능 추가, 캠프파이어 방 추가, 버그 개선

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import Main from '@pages/Main';
 import { useUser, useUserFns } from '@contexts/userContext';
 import { getUserByToken } from '@src/apis';
 import Room from '@pages/Room';
+import CampFire from '@pages/Campfire';
 import Profile from '@pages/Profile';
 
 const App = (): JSX.Element => {
@@ -32,7 +33,8 @@ const App = (): JSX.Element => {
         <Switch>
           <Route exact path="/" component={Introduction} />
           <Route path="/main" component={Main} />
-          <Route path="/room" component={Room} />
+          <Route path="/room/tadak" component={Room} />
+          <Route path="/room/campfire" component={CampFire} />
           <Route path="/profile" component={Profile} />
           <Redirect from="*" to="/" />
         </Switch>

--- a/client/src/components/RoomBox.tsx
+++ b/client/src/components/RoomBox.tsx
@@ -102,7 +102,7 @@ const RoomBox = ({ roomInfo }: RoomBoxProps): JSX.Element => {
   const history = useHistory();
 
   const verifyBySocket = useCallback(async () => {
-    socket.emit('verify-room', { roomId: uuid });
+    socket.emit('verify-room', { uuid });
   }, [uuid]);
 
   const onClickRoomBox = useCallback(async () => {

--- a/client/src/components/RoomBox.tsx
+++ b/client/src/components/RoomBox.tsx
@@ -4,6 +4,7 @@ import { getRoomByUuid, postEnterRoom } from '@src/apis';
 import { useHistory } from 'react-router';
 import { useCallback, useEffect, useRef } from 'react';
 import socket from '@src/socket';
+import { useUser } from '@src/contexts/userContext';
 
 const ROOM_WIDTH = 20;
 const ROOM_HEIGHT = ROOM_WIDTH * 0.75;
@@ -95,6 +96,7 @@ interface RoomBoxProps {
 
 const RoomBox = ({ roomInfo }: RoomBoxProps): JSX.Element => {
   const { uuid, title, description, nowHeadcount, maxHeadcount } = roomInfo;
+  const { login } = useUser();
   const roomDataRef = useRef<RoomInfo>();
   const history = useHistory();
 
@@ -103,13 +105,17 @@ const RoomBox = ({ roomInfo }: RoomBoxProps): JSX.Element => {
   }, [uuid]);
 
   const onClickRoomBox = useCallback(async () => {
+    if (!login) {
+      // 로그인을 해야 입장 가능하다는 알람을 띄워줘야 한다.
+      return;
+    }
     const { isOk, data } = await getRoomByUuid(uuid);
     if (isOk && data) {
       if (data.nowHeadcount >= data.maxHeadcount) return;
       roomDataRef.current = data;
       verifyBySocket();
     }
-  }, [uuid, verifyBySocket]);
+  }, [uuid, login, verifyBySocket]);
 
   const enterRoom = useCallback(() => {
     postEnterRoom(uuid);

--- a/client/src/components/RoomBox.tsx
+++ b/client/src/components/RoomBox.tsx
@@ -5,6 +5,7 @@ import { useHistory } from 'react-router';
 import { useCallback, useEffect, useRef } from 'react';
 import socket from '@src/socket';
 import { useUser } from '@src/contexts/userContext';
+import { RoomType } from '@components/main/RoomList';
 
 const ROOM_WIDTH = 20;
 const ROOM_HEIGHT = ROOM_WIDTH * 0.75;
@@ -78,7 +79,7 @@ const RoomBoxBottom = styled.div`
   align-items: flex-end;
 `;
 
-const RoomType = styled.div`
+const RoomFieldType = styled.div`
   ${({ theme }) => css`
     font-size: ${theme.fontSizes.sm};
     background-color: ${theme.colors.blue};
@@ -95,7 +96,7 @@ interface RoomBoxProps {
 }
 
 const RoomBox = ({ roomInfo }: RoomBoxProps): JSX.Element => {
-  const { uuid, title, description, nowHeadcount, maxHeadcount } = roomInfo;
+  const { uuid, title, description, nowHeadcount, maxHeadcount, roomType } = roomInfo;
   const { login } = useUser();
   const roomDataRef = useRef<RoomInfo>();
   const history = useHistory();
@@ -118,9 +119,10 @@ const RoomBox = ({ roomInfo }: RoomBoxProps): JSX.Element => {
   }, [uuid, login, verifyBySocket]);
 
   const enterRoom = useCallback(() => {
+    const pathname = roomType === RoomType.tadak ? `/room/tadak/${uuid}` : `/room/campfire/${uuid}`;
     postEnterRoom(uuid);
-    history.push({ pathname: `/room/${uuid}`, state: roomDataRef.current });
-  }, [history, uuid, roomDataRef]);
+    history.push({ pathname, state: roomDataRef.current });
+  }, [history, uuid, roomType, roomDataRef]);
 
   useEffect(() => {
     socket.removeListener('is-verify');
@@ -134,7 +136,7 @@ const RoomBox = ({ roomInfo }: RoomBoxProps): JSX.Element => {
         <RoomDescription>{description}</RoomDescription>
       </RoomBoxTop>
       <RoomBoxBottom>
-        <RoomType>백엔드</RoomType>
+        <RoomFieldType>백엔드</RoomFieldType>
         <RoomAdmitNumber>
           {nowHeadcount} / {maxHeadcount}
         </RoomAdmitNumber>

--- a/client/src/components/main/CreateForm.tsx
+++ b/client/src/components/main/CreateForm.tsx
@@ -6,6 +6,7 @@ import { postRoom } from '@src/apis';
 import { useUser } from '@contexts/userContext';
 import Select from '@components/common/Select';
 import { adminOptions } from '@utils/utils';
+import { RoomType } from './RoomList';
 
 const Container = styled.div`
   ${({ theme }) => theme.flexCenter}
@@ -41,7 +42,7 @@ const Button = styled.button`
   border-radius: 1rem;
 `;
 
-enum RoomType {
+enum RoomIndexType {
   타닥타닥 = 1,
   캠프파이어 = 2,
 }
@@ -52,14 +53,14 @@ type OptionType = {
 };
 
 const roomOptions: OptionType[] = [
-  { value: RoomType.타닥타닥, label: '타닥타닥' },
-  { value: RoomType.캠프파이어, label: '캠프파이어' },
+  { value: RoomIndexType.타닥타닥, label: '타닥타닥' },
+  { value: RoomIndexType.캠프파이어, label: '캠프파이어' },
 ];
 
 const CreateForm = (): JSX.Element => {
   const [roomTitle, onChangeRoomTitle] = useInput('');
   const [description, onChangeDescription] = useInput('');
-  const [roomType, setRoomType] = useState(RoomType[1]);
+  const [roomType, setRoomType] = useState(RoomIndexType[1]);
   const [maxHeadcount, setMaxHeadcount] = useState('');
   const user = useUser();
   const history = useHistory();
@@ -84,7 +85,8 @@ const CreateForm = (): JSX.Element => {
     const { isOk, data } = await postRoom(requestBody);
     if (isOk && data) {
       const { uuid } = data;
-      history.push(`/room/${uuid}`, data);
+      const pathname = data.roomType === RoomType.tadak ? `/room/tadak/${uuid}` : `/room/campfire/${uuid}`;
+      history.push(pathname, data);
     }
   };
 

--- a/client/src/components/main/RoomList.tsx
+++ b/client/src/components/main/RoomList.tsx
@@ -46,7 +46,7 @@ interface TabState {
   campfire: boolean;
 }
 
-enum RoomType {
+export enum RoomType {
   tadak = '타닥타닥',
   campfire = '캠프파이어',
 }

--- a/client/src/components/room/campfire/CamperAvatar.tsx
+++ b/client/src/components/room/campfire/CamperAvatar.tsx
@@ -1,0 +1,66 @@
+import { IRemoteAudioTrack, IMicrophoneAudioTrack } from 'agora-rtc-react';
+import styled from 'styled-components';
+import defaultImage from '@assets/default-avatar.jpeg';
+import { useEffect, useState, useRef, useCallback } from 'react';
+
+const CAMPER_WIDTH = '5rem';
+const CAMPER_HEIGHT = '5rem';
+const BORDER_RADIUS = '3rem';
+
+const CamperIcon = styled.div`
+  ${({ theme }) => theme.flexCenter};
+  width: ${CAMPER_WIDTH};
+  height: ${CAMPER_HEIGHT};
+  margin: ${({ theme }) => theme.margins.sm};
+  background-image: url(${defaultImage});
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  border-radius: ${BORDER_RADIUS};
+  overflow: hidden;
+  position: relative;
+`;
+
+const VolumeVisualizer = styled.div`
+  width: ${CAMPER_WIDTH};
+  height: ${CAMPER_HEIGHT};
+  position: absolute;
+  right: 0;
+  border: 3px solid ${({ theme }) => theme.colors.blue};
+  border-radius: ${BORDER_RADIUS};
+`;
+
+const SPEAK_VOLUME = 0.2;
+const VOLUME_VISUAL_TIME = 1000;
+
+interface CamperAvatarProps {
+  audioTrack: IMicrophoneAudioTrack | IRemoteAudioTrack | undefined;
+}
+
+const CamperAvatar = ({ audioTrack }: CamperAvatarProps): JSX.Element => {
+  const [isSpeak, setIsSpeak] = useState(false);
+  const isInterval = useRef(false);
+  const initInterval = useCallback(
+    function () {
+      if (!isInterval.current) {
+        setInterval(() => {
+          if (audioTrack) {
+            setIsSpeak(audioTrack?.getVolumeLevel() > SPEAK_VOLUME);
+          }
+        }, VOLUME_VISUAL_TIME);
+      }
+      isInterval.current = true;
+    },
+    [isInterval, audioTrack],
+  );
+
+  useEffect(() => {
+    if (audioTrack) {
+      initInterval();
+    }
+  }, [audioTrack, initInterval]);
+
+  return <CamperIcon>{isSpeak && <VolumeVisualizer />}</CamperIcon>;
+};
+
+export default CamperAvatar;

--- a/client/src/components/room/campfire/CamperList.tsx
+++ b/client/src/components/room/campfire/CamperList.tsx
@@ -1,0 +1,46 @@
+import { IAgoraRTCRemoteUser, IMicrophoneAudioTrack } from 'agora-rtc-react';
+import styled, { css } from 'styled-components';
+import CamperAvatar from './CamperAvatar';
+
+const CamperListWrapper = styled.div`
+  position: relative;
+`;
+
+const CamperListContainer = styled.div`
+  position: fixed;
+  padding: ${({ theme }) => theme.paddings.lg};
+  ${({ theme }) => css`
+    ${theme.flexCenter};
+    bottom: 12rem;
+    left: 29rem;
+    right: 0;
+  `};
+`;
+
+const CamperAvatarList = styled.div`
+  ${({ theme }) => css`
+    ${theme.flexCenter};
+    border: 1px solid ${theme.colors.borderGrey};
+    border-radius: ${theme.borderRadius.sm};
+  `};
+`;
+
+interface CamperListProps {
+  users: IAgoraRTCRemoteUser[];
+  track: IMicrophoneAudioTrack;
+}
+
+const CamperList = ({ users, track }: CamperListProps): JSX.Element => {
+  return (
+    <CamperListWrapper>
+      <CamperListContainer>
+        <CamperAvatarList>
+          <CamperAvatar audioTrack={track} />
+          {users.length > 0 && users.map((user) => <CamperAvatar key={user.uid} audioTrack={user.audioTrack} />)}
+        </CamperAvatarList>
+      </CamperListContainer>
+    </CamperListWrapper>
+  );
+};
+
+export default CamperList;

--- a/client/src/components/room/campfire/CampfireController.tsx
+++ b/client/src/components/room/campfire/CampfireController.tsx
@@ -1,0 +1,95 @@
+import React, { useState, useCallback, useEffect, useContext } from 'react';
+import { useHistory } from 'react-router';
+import { IMicrophoneAudioTrack } from 'agora-rtc-react';
+import styled, { css, ThemeContext } from 'styled-components';
+import { FaMicrophone, FaMicrophoneSlash } from 'react-icons/fa';
+import { MdOutlineExitToApp } from 'react-icons/md';
+import { useClient } from '../tadaktadak/videoConfig';
+import Button from '@components/common/Button';
+import { deleteRoom } from '@src/apis';
+import { useUser } from '@contexts/userContext';
+
+const ButtonContainer = styled.div`
+  position: relative;
+`;
+const Controls = styled.div`
+  position: fixed;
+  ${({ theme }) => css`
+    ${theme.flexCenter}
+    bottom: ${theme.margins.xl};
+    left: 29rem;
+    right: 0;
+  `}
+`;
+
+const GetoutDiv = styled.div`
+  position: fixed;
+  ${({ theme }) => css`
+    top: ${theme.margins.xl};
+    right: ${theme.margins.sm};
+  `}
+`;
+
+interface CampfireControllerProps {
+  track: IMicrophoneAudioTrack;
+  setStart: React.Dispatch<React.SetStateAction<boolean>>;
+  uuid: string;
+  ownerId: number | undefined;
+}
+
+const CampfireController = ({ track, setStart, uuid, ownerId }: CampfireControllerProps): JSX.Element => {
+  const client = useClient();
+  const history = useHistory();
+  const themeContext = useContext(ThemeContext);
+  const user = useUser();
+  const [trackState, setTrackState] = useState({ audio: false });
+
+  const mute = async () => {
+    await track.setEnabled(!trackState.audio);
+    setTrackState((ps) => {
+      return { ...ps, audio: !ps.audio };
+    });
+  };
+
+  const leaveChannel = useCallback(async () => {
+    if (ownerId === user.id) deleteRoom({ uuid });
+    await client.leave();
+    client.removeAllListeners();
+    track.close();
+    setStart(false);
+  }, [client, track, uuid, ownerId, user, setStart]);
+
+  useEffect(() => {
+    return history.listen(() => {
+      if (history.action === 'POP') {
+        leaveChannel();
+      }
+    });
+  }, [history, leaveChannel]);
+
+  return (
+    <ButtonContainer>
+      <Controls>
+        <Button
+          icon={trackState.audio ? <FaMicrophone fill="white" /> : <FaMicrophoneSlash />}
+          text={''}
+          className={trackState.audio ? 'on' : ''}
+          onClick={() => mute()}
+        />
+      </Controls>
+      <GetoutDiv>
+        <Button
+          icon={<MdOutlineExitToApp fill="white" />}
+          text={''}
+          color={themeContext.colors.secondary}
+          onClick={() => {
+            leaveChannel();
+            history.replace('/main');
+          }}
+        />
+      </GetoutDiv>
+    </ButtonContainer>
+  );
+};
+
+export default CampfireController;

--- a/client/src/components/room/campfire/CampfireController.tsx
+++ b/client/src/components/room/campfire/CampfireController.tsx
@@ -60,6 +60,7 @@ const CampfireController = ({ track, setStart, uuid, ownerId }: CampfireControll
   }, [client, track, uuid, ownerId, user, setStart]);
 
   useEffect(() => {
+    window.onbeforeunload = leaveChannel;
     return history.listen(() => {
       if (history.action === 'POP') {
         leaveChannel();

--- a/client/src/components/room/tadaktadak/ChatList.tsx
+++ b/client/src/components/room/tadaktadak/ChatList.tsx
@@ -59,7 +59,7 @@ const ChatList = ({ uuid, chats, setChats }: ChatListProps<string>): JSX.Element
 
   const sendMessage = useCallback(() => {
     if (!message) return;
-    const myMessage = { type: 'string', nickname, message, roomId: uuid };
+    const myMessage = { type: 'string', nickname, message, uuid };
     socket.emit('msgToServer', myMessage);
     onResetMessage();
   }, [onResetMessage, nickname, message, uuid]);

--- a/client/src/components/room/tadaktadak/ParticipantList.tsx
+++ b/client/src/components/room/tadaktadak/ParticipantList.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useCallback, useContext } from 'react';
 import styled, { css, ThemeContext } from 'styled-components';
 import { FieldName, useUser } from '@src/contexts/userContext';
 import socket from '@src/socket';
@@ -74,11 +74,14 @@ const ParticipantList = ({
   const themeContext = useContext(ThemeContext);
   const user = useUser();
 
-  const onClickGetOutBtn = (e: React.MouseEvent<HTMLDivElement>) => {
-    const kickNickname = e.currentTarget.getAttribute('data-nickname');
-    if (!kickNickname) return;
-    socket.emit('kick-room', { roomId: uuid, kickNickname });
-  };
+  const onClickGetOutBtn = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const kickNickname = e.currentTarget.getAttribute('data-nickname');
+      if (!kickNickname) return;
+      socket.emit('kick-room', { roomId: uuid, kickNickname });
+    },
+    [uuid],
+  );
 
   return (
     <Container>

--- a/client/src/components/room/tadaktadak/ParticipantList.tsx
+++ b/client/src/components/room/tadaktadak/ParticipantList.tsx
@@ -4,6 +4,7 @@ import { FieldName } from '@src/contexts/userContext';
 
 interface ParticipantListProps<T> {
   participants: Record<string, T>;
+  hostNickname: string | undefined;
 }
 
 const Container = styled.div`
@@ -47,8 +48,13 @@ const DevField = styled.div<{ bgColor: string }>`
   `}
 `;
 
+const Position = styled.div`
+  margin-left: ${({ theme }) => theme.margins.xs};
+`;
+
 const ParticipantList = ({
   participants,
+  hostNickname,
 }: ParticipantListProps<{ field: { id: number; name: FieldName }; img: string }>): JSX.Element => {
   const themeContext = useContext(ThemeContext);
 
@@ -60,6 +66,7 @@ const ParticipantList = ({
             <Avatar src={img} />
             <Nickname>{nickname}</Nickname>
             {field && <DevField bgColor={themeContext.tagColors[field.name]}>{field.name}</DevField>}
+            {hostNickname === nickname && <Position>호스트</Position>}
           </Participant>
         ))}
       </List>

--- a/client/src/components/room/tadaktadak/ParticipantList.tsx
+++ b/client/src/components/room/tadaktadak/ParticipantList.tsx
@@ -78,7 +78,7 @@ const ParticipantList = ({
     (e: React.MouseEvent<HTMLDivElement>) => {
       const kickNickname = e.currentTarget.getAttribute('data-nickname');
       if (!kickNickname) return;
-      socket.emit('kick-room', { roomId: uuid, kickNickname });
+      socket.emit('kick-room', { uuid, kickNickname });
     },
     [uuid],
   );

--- a/client/src/components/room/tadaktadak/RoomSideBar.tsx
+++ b/client/src/components/room/tadaktadak/RoomSideBar.tsx
@@ -54,7 +54,7 @@ const RoomSideBar = ({ uuid, hostNickname }: RoomSideBarProps): JSX.Element => {
   const onClickParticipantTap = () => setTabs({ ...initialTabState, isParticipant: !isParticipant });
 
   const leaveSocket = useCallback(() => {
-    const leavePayload = { nickname, roomId: uuid };
+    const leavePayload = { nickname, uuid };
     socket.emit('leave-room', leavePayload);
     postLeaveRoom(uuid);
   }, [nickname, uuid]);
@@ -75,7 +75,7 @@ const RoomSideBar = ({ uuid, hostNickname }: RoomSideBarProps): JSX.Element => {
   );
 
   const initSocket = useCallback(() => {
-    const joinPayload = { nickname, roomId: uuid, field: devField, img: imageUrl };
+    const joinPayload = { nickname, uuid, field: devField, img: imageUrl };
     socket.emit('join-room', joinPayload);
     socket.on('user-list', registerParticipants);
   }, [nickname, devField, imageUrl, uuid, registerParticipants]);

--- a/client/src/components/room/tadaktadak/RoomSideBar.tsx
+++ b/client/src/components/room/tadaktadak/RoomSideBar.tsx
@@ -61,7 +61,7 @@ const RoomSideBar = ({ uuid, hostNickname }: RoomSideBarProps): JSX.Element => {
 
   const exitRoom = useCallback(() => {
     leaveSocket();
-    history.push('/main');
+    history.replace('/main');
   }, [history, leaveSocket]);
 
   const registerParticipants = useCallback(

--- a/client/src/components/room/tadaktadak/RoomSideBar.tsx
+++ b/client/src/components/room/tadaktadak/RoomSideBar.tsx
@@ -38,9 +38,10 @@ const initialTabState = {
 
 interface RoomSideBarProps {
   uuid: string;
+  hostNickname: string | undefined;
 }
 
-const RoomSideBar = ({ uuid }: RoomSideBarProps): JSX.Element => {
+const RoomSideBar = ({ uuid, hostNickname }: RoomSideBarProps): JSX.Element => {
   const { nickname, devField, imageUrl } = useUser();
   const [tabs, setTabs] = useState({ ...initialTabState });
   const [chats, setChats] = useState<Array<Record<string, string | undefined>>>([]);
@@ -77,7 +78,7 @@ const RoomSideBar = ({ uuid }: RoomSideBarProps): JSX.Element => {
       </SideBarTopMenus>
       <SideBarBottomMenus>
         {isChat && <ChatList chats={chats} uuid={uuid} setChats={setChats} />}
-        {isParticipant && <ParticipantList participants={participants} />}
+        {isParticipant && <ParticipantList participants={participants} hostNickname={hostNickname} />}
       </SideBarBottomMenus>
     </SideBarContainer>
   );

--- a/client/src/components/room/tadaktadak/VideoController.tsx
+++ b/client/src/components/room/tadaktadak/VideoController.tsx
@@ -73,6 +73,7 @@ const VideoController = ({ tracks, setStart, uuid, ownerId }: VideoControllerPro
   }, [client, tracks, uuid, ownerId, user, setStart]);
 
   useEffect(() => {
+    window.onbeforeunload = leaveChannel;
     return history.listen(() => {
       if (history.action === 'POP') {
         leaveChannel();

--- a/client/src/components/room/tadaktadak/videoConfig.ts
+++ b/client/src/components/room/tadaktadak/videoConfig.ts
@@ -1,4 +1,9 @@
-import { createClient, ClientConfig, createMicrophoneAndCameraTracks } from 'agora-rtc-react';
+import {
+  createClient,
+  ClientConfig,
+  createMicrophoneAndCameraTracks,
+  createMicrophoneAudioTrack,
+} from 'agora-rtc-react';
 
 const config: ClientConfig = {
   mode: 'rtc',
@@ -7,5 +12,6 @@ const config: ClientConfig = {
 
 const useClient = createClient(config);
 const useMicrophoneAndCameraTracks = createMicrophoneAndCameraTracks();
+const useMicrophoneTrack = createMicrophoneAudioTrack();
 
-export { useClient, useMicrophoneAndCameraTracks };
+export { useClient, useMicrophoneAndCameraTracks, useMicrophoneTrack };

--- a/client/src/pages/Campfire/Campfire.tsx
+++ b/client/src/pages/Campfire/Campfire.tsx
@@ -19,9 +19,9 @@ interface RoomProps {
 const Campfire = ({ location }: RoomProps): JSX.Element => {
   const { agoraAppId, agoraToken, uuid, owner } = location.state;
   const [users, setUsers] = useState<IAgoraRTCRemoteUser[]>([]);
-  const [start, setStart] = useState<boolean>(false); // start: 서버에 초기화 완료
+  const [start, setStart] = useState<boolean>(false);
   const client = useClient();
-  const { ready, track } = useMicrophoneTrack(); // ready: 클라이언트 트랙 준비 여부
+  const { ready, track } = useMicrophoneTrack();
 
   useEffect(() => {
     const init = async () => {

--- a/client/src/pages/Campfire/Campfire.tsx
+++ b/client/src/pages/Campfire/Campfire.tsx
@@ -2,9 +2,10 @@ import { useState, useEffect } from 'react';
 import { IAgoraRTCRemoteUser } from 'agora-rtc-react';
 import { useClient, useMicrophoneTrack } from '../../components/room/tadaktadak/videoConfig';
 import { RoomInfo } from '@components/main/RoomList';
-import { RoomContainer, RoomWrapper } from '@pages/Room/style';
+import { RoomContainer, RoomWrapper } from '@pages/Campfire/style';
 import RoomSideBar from '@components/room/tadaktadak/RoomSideBar';
 import CampfireController from '@src/components/room/campfire/CampfireController';
+import CamperList from '@src/components/room/campfire/CamperList';
 
 interface LocationProps {
   pathname: string;
@@ -69,6 +70,13 @@ const Campfire = ({ location }: RoomProps): JSX.Element => {
     <RoomWrapper>
       <RoomSideBar uuid={uuid} hostNickname={owner?.nickname} />
       <RoomContainer>
+        <div>
+          <img
+            src="https://cdn.pixabay.com/photo/2016/05/27/04/20/fire-1419084_1280.jpg"
+            style={{ width: '500px', height: '500px' }}
+          />
+        </div>
+        {start && track && <CamperList users={users} track={track} />}
         {ready && track && <CampfireController track={track} setStart={setStart} uuid={uuid} ownerId={owner?.id} />}
       </RoomContainer>
     </RoomWrapper>

--- a/client/src/pages/Campfire/Campfire.tsx
+++ b/client/src/pages/Campfire/Campfire.tsx
@@ -1,0 +1,77 @@
+import { useState, useEffect } from 'react';
+import { IAgoraRTCRemoteUser } from 'agora-rtc-react';
+import { useClient, useMicrophoneTrack } from '../../components/room/tadaktadak/videoConfig';
+import { RoomInfo } from '@components/main/RoomList';
+import { RoomContainer, RoomWrapper } from '@pages/Room/style';
+import RoomSideBar from '@components/room/tadaktadak/RoomSideBar';
+import CampfireController from '@src/components/room/campfire/CampfireController';
+
+interface LocationProps {
+  pathname: string;
+  state: RoomInfo;
+}
+
+interface RoomProps {
+  location: LocationProps;
+}
+
+const Campfire = ({ location }: RoomProps): JSX.Element => {
+  const { agoraAppId, agoraToken, uuid, owner } = location.state;
+  const [users, setUsers] = useState<IAgoraRTCRemoteUser[]>([]);
+  const [start, setStart] = useState<boolean>(false); // start: 서버에 초기화 완료
+  const client = useClient();
+  const { ready, track } = useMicrophoneTrack(); // ready: 클라이언트 트랙 준비 여부
+
+  useEffect(() => {
+    const init = async () => {
+      client.on('user-published', async (user, mediaType) => {
+        await client.subscribe(user, mediaType);
+        console.log('subscribe success');
+        if (mediaType === 'audio') {
+          setUsers((prevUsers) => [...new Set([...prevUsers, user])]);
+          user.audioTrack?.play();
+        }
+      });
+
+      client.on('user-joined', (user) => {
+        setUsers((prevUsers) => [...new Set([...prevUsers, user])]);
+      });
+
+      client.on('user-unpublished', (user, type) => {
+        console.log('unpublished', user, type);
+        if (type === 'audio') {
+          user.audioTrack?.stop();
+        }
+      });
+
+      client.on('user-left', (user) => {
+        console.log('leaving', user);
+        setUsers((prevUsers) => {
+          return prevUsers.filter((User) => User.uid !== user.uid);
+        });
+      });
+
+      await client.join(agoraAppId, uuid, agoraToken, null);
+      if (track) {
+        await client.publish(track);
+        await track.setEnabled(false);
+      }
+      setStart(true);
+    };
+
+    if (ready && track) {
+      console.log('init ready');
+      init();
+    }
+  }, [uuid, agoraAppId, agoraToken, client, ready, track]);
+
+  return (
+    <RoomWrapper>
+      <RoomSideBar uuid={uuid} hostNickname={owner?.nickname} />
+      <RoomContainer>
+        {ready && track && <CampfireController track={track} setStart={setStart} uuid={uuid} ownerId={owner?.id} />}
+      </RoomContainer>
+    </RoomWrapper>
+  );
+};
+export default Campfire;

--- a/client/src/pages/Campfire/index.ts
+++ b/client/src/pages/Campfire/index.ts
@@ -1,0 +1,3 @@
+import CampFire from './Campfire';
+
+export default CampFire;

--- a/client/src/pages/Campfire/style.ts
+++ b/client/src/pages/Campfire/style.ts
@@ -10,4 +10,5 @@ export const RoomContainer = styled.div`
   height: 100%;
   width: 100%;
   padding: ${({ theme }) => theme.paddings.lg};
+  ${({ theme }) => theme.flexCenter};
 `;

--- a/client/src/pages/Campfire/style.ts
+++ b/client/src/pages/Campfire/style.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const RoomWrapper = styled.div`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+`;
+
+export const RoomContainer = styled.div`
+  height: 100%;
+  width: 100%;
+  padding: ${({ theme }) => theme.paddings.lg};
+`;

--- a/client/src/pages/Room/Room.tsx
+++ b/client/src/pages/Room/Room.tsx
@@ -74,7 +74,7 @@ const Room = ({ location }: RoomProps): JSX.Element => {
 
   return (
     <RoomWrapper>
-      <RoomSideBar uuid={uuid} />
+      <RoomSideBar uuid={uuid} hostNickname={owner?.nickname} />
       <RoomContainer>
         {start && tracks && <Videos users={users} tracks={tracks} />}
         {ready && tracks && <VideoController tracks={tracks} setStart={setStart} uuid={uuid} ownerId={owner?.id} />}


### PR DESCRIPTION
## 개요
호스트의 추방 기능을 추가했습니다.
캠프파이어 방을 추가했습니다.
몇 가지 버그를 개선했습니다.

## 작업 사항
- 비로그인 시 메인화면에서 방에 입장할 수 없습니다.
- 호스트가 브라우저를 강제 종료해도 방을 닫을 수 있도록 했습니다.

- 방의 사이드바에서 호스트의 고유 권한인 추방 기능을 추가했습니다.
  - 호스트는 사이드바의 참가자 리스트 탭에서 추방하고자 하는 참가자를 추방할 수 있습니다.
  - 참가자는 소켓에 의해 받은 새로운 참가자 리스트에 자신이 없다면 메인으로 이동합니다.
     - 그러므로 직접 url을 통해 방에 접속한 비로그인 유저가 있다고 해도, 자동으로 메인으로 이동됩니다.

- 새로운 타입의 방인 캠프파이어 방을 추가했습니다.
  - 캠프파이어 방에서는 음성과 채팅만 공유됩니다.
  - 참가한 참여자는 캠퍼이며, 캠퍼의 인원만큼 캠퍼아바타가 보여집니다.
  - 발화자의 캠퍼 아바타의 경계는 하이라이트 기능이 제공됩니다.
  - 방의 사이드바는 타닥타닥방과 공유하기 때문에, 동일한 기능을 사용할 수 있습니다.

## 현재 캠프파이어 방 상태

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/67041709/142996747-04d26bcc-9284-4eac-a06a-ee61ea02f4d1.png">

## 🧐고민고민
- 추방 기능을 구현했지만, 현재 추방된 유저는 다시 추방된 방에 재접속 할 수 있습니다.
- 캠프파이어 방 내에서의 불 애니메이션......