### PR TITLE
유저 닉네임 수정 길이 제한

### DIFF
--- a/client/src/components/profile/ModifyInfoCard/index.tsx
+++ b/client/src/components/profile/ModifyInfoCard/index.tsx
@@ -6,7 +6,7 @@ import { useDevField } from '@contexts/devFieldContext';
 import { useToast } from '@hooks/useToast';
 import useInput from '@hooks/useInput';
 import { patchUpdate } from '@src/apis';
-import { TOAST_MESSAGE } from '@utils/constant';
+import { INPUT, TOAST_MESSAGE } from '@utils/constant';
 
 interface InfoProps {
   onnClickCancelBtn: React.MouseEventHandler<HTMLButtonElement>;
@@ -47,7 +47,7 @@ const ModifyInfoCard = ({ onnClickCancelBtn, setIsModify }: InfoProps): JSX.Elem
         </InfoSet>
         <InfoSet>
           <Legend>{`닉네임`}</Legend>
-          <Input type="text" value={nickname} onChange={onChangeNickname}></Input>
+          <Input type="text" value={nickname} onChange={onChangeNickname} maxLength={INPUT.nicknameMaxLen}></Input>
         </InfoSet>
         <InfoSet>
           <Legend>{`관심 분야`}</Legend>


### PR DESCRIPTION
유저 정보 페이지에서 유저 닉네임을 수정할 때 길이 제한이 없어서 추가했습니다.