### PR TITLE
강퇴 시 소켓이 끊기는 버그 개선, 토스트메시지 수정

### DIFF
--- a/client/src/components/campfire/CamperList/index.tsx
+++ b/client/src/components/campfire/CamperList/index.tsx
@@ -20,8 +20,8 @@ const CamperList = ({ users, track }: CamperListProps): JSX.Element => {
           </CamperWrapper>
           {users.length > 0 &&
             users.map((user) => (
-              <CamperWrapper>
-                <CamperAvatar key={user.uid} audioTrack={user.audioTrack} />
+              <CamperWrapper key={user.uid}>
+                <CamperAvatar audioTrack={user.audioTrack} />
                 <CamperInfoDiv>{decodeURI(String(user.uid))}</CamperInfoDiv>
               </CamperWrapper>
             ))}

--- a/client/src/components/form/Join/index.tsx
+++ b/client/src/components/form/Join/index.tsx
@@ -31,8 +31,10 @@ const JoinForm = ({ onClickModalToggle, setIsLogin }: JoinProps): JSX.Element =>
     if (!isPassword(password)) return toast('error', TOAST_MESSAGE.invalidFormatPwd);
     if (!devField) return toast('error', TOAST_MESSAGE.emptyDevField);
     const requestBody = { email, nickname, password, devField: +devField };
-    const { isOk } = await postJoin(requestBody);
-    if (!isOk) return toast('error', TOAST_MESSAGE.alreadyEmail);
+    const { isOk, errorData } = await postJoin(requestBody);
+    if (!isOk && errorData) {
+      return toast('error', errorData.message);
+    }
     setIsLogin(true);
     toast('success', TOAST_MESSAGE.joinSuccess);
   };

--- a/client/src/components/form/MakeRoom/index.tsx
+++ b/client/src/components/form/MakeRoom/index.tsx
@@ -38,6 +38,7 @@ const CreateForm = (): JSX.Element => {
   const onSubmitForm = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!roomTitle) return toast('error', TOAST_MESSAGE.emptyTitle);
+    if (!description) return toast('error', TOAST_MESSAGE.emptyDescription);
     if (!roomType) return toast('error', TOAST_MESSAGE.emptyRoomType);
     if (!maxHeadcount) return toast('error', TOAST_MESSAGE.emptyHeadcount);
     const requestBody = {

--- a/client/src/components/sideBar/Room/index.tsx
+++ b/client/src/components/sideBar/Room/index.tsx
@@ -49,6 +49,7 @@ const RoomSideBar = ({ uuid, hostNickname, maxHeadcount, roomType }: RoomSideBar
     if (!isKicked.current) {
       socket.emit(SocketEvents.leaveRoom, { uuid });
     }
+    socket.removeAllListeners();
     postLeaveRoom(uuid);
   }, [uuid]);
 
@@ -60,7 +61,6 @@ const RoomSideBar = ({ uuid, hostNickname, maxHeadcount, roomType }: RoomSideBar
 
   const registerParticipants = useCallback(
     (userList: ParticipantsProps) => {
-      console.log(userList);
       if (!nickname || !userList[socket.id]) {
         isKicked.current = true;
         return exitRoom();

--- a/client/src/components/sideBar/Room/index.tsx
+++ b/client/src/components/sideBar/Room/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router';
 import { Tabs } from './style';
 import { SocketEvents } from '@socket/socketEvents';
@@ -40,12 +40,15 @@ const RoomSideBar = ({ uuid, hostNickname, maxHeadcount, roomType }: RoomSideBar
   const [chats, setChats] = useState<Array<Record<string, string | undefined>>>([]);
   const [participants, setParticipants] = useState({});
   const { isChat, isParticipant } = tabs;
+  const isKicked = useRef(false);
 
   const onClickChatTap = () => setTabs({ ...initialTabState, isChat: !isChat });
   const onClickParticipantTap = () => setTabs({ ...initialTabState, isParticipant: !isParticipant });
 
   const leaveSocket = useCallback(() => {
-    socket.emit(SocketEvents.leaveRoom, { uuid });
+    if (!isKicked.current) {
+      socket.emit(SocketEvents.leaveRoom, { uuid });
+    }
     postLeaveRoom(uuid);
   }, [uuid]);
 
@@ -57,13 +60,18 @@ const RoomSideBar = ({ uuid, hostNickname, maxHeadcount, roomType }: RoomSideBar
 
   const registerParticipants = useCallback(
     (userList: ParticipantsProps) => {
-      if (!nickname || !userList[socket.id]) return exitRoom();
+      console.log(userList);
+      if (!nickname || !userList[socket.id]) {
+        isKicked.current = true;
+        return exitRoom();
+      }
       setParticipants({ ...userList });
     },
     [nickname, exitRoom],
   );
 
   const initSocket = useCallback(() => {
+    if (!nickname) return;
     const joinPayload = { nickname, uuid, field: devField, img: imageUrl, maxHead: maxHeadcount };
     socket.emit(SocketEvents.joinRoom, joinPayload);
     socket.on(SocketEvents.receiveUserList, registerParticipants);
@@ -72,7 +80,7 @@ const RoomSideBar = ({ uuid, hostNickname, maxHeadcount, roomType }: RoomSideBar
   useEffect(() => {
     initSocket();
     return leaveSocket;
-  }, [initSocket, leaveSocket]);
+  }, [initSocket, leaveSocket, uuid, isKicked]);
 
   return (
     <SideBar

--- a/client/src/components/sideBar/SideBar/style.ts
+++ b/client/src/components/sideBar/SideBar/style.ts
@@ -4,7 +4,7 @@ import { SIDEBAR } from '@utils/styleConstant';
 export const Container = styled.div<{ bgColor?: string; borderColor?: string }>`
   ${({ theme, bgColor, borderColor }) => css`
     ${theme.flexColumn};
-    padding: ${theme.paddings.lg};
+    padding: ${theme.paddings.base};
     background-color: ${bgColor || theme.colors.white};
     border: 1px solid ${borderColor || theme.colors.borderGrey};
   `};

--- a/client/src/components/sideBar/chat/ChatList/style.ts
+++ b/client/src/components/sideBar/chat/ChatList/style.ts
@@ -28,11 +28,14 @@ export const TextAreaWrapper = styled.div`
 export const TextArea = styled.textarea`
   width: ${CHAT.inputWidth};
   height: 6rem;
+  min-height: 4rem;
+  max-height: 7.5rem;
   font-size: ${CHAT.fontSize};
   padding: ${({ theme }) => theme.paddings.sm};
   border: 2px solid ${({ theme }) => theme.colors.borderGrey};
   border-radius: ${({ theme }) => theme.borderRadius.base};
   background-color: transparent;
+  resize: vertical;
   ::placeholder {
     font-size: ${CHAT.fontSize};
   }

--- a/client/src/utils/constant.ts
+++ b/client/src/utils/constant.ts
@@ -75,13 +75,14 @@ export const TOAST_MESSAGE = {
   alreadyRoom: '방은 최대 1개까지 생성할 수 있습니다.',
   emptyDevField: '개발 분야를 선택해주세요.',
   emptyTitle: '방 제목을 입력해주세요.',
+  emptyDescription: '방 설명을 입력해주세요.',
   emptyRoomType: '방 유형을 선택해주세요.',
   emptyHeadcount: '최대 입장 가능한 인원을 선택해주세요.',
 };
 
 export const PLACEHOLDER_TXT = {
   roomTitle: `방 제목을 입력해주세요. (최대 ${INPUT.roomTitleMaxLen}자)`,
-  roomDiscrpt: '방에 대한 설명을 입력해주세요.(선택)',
+  roomDiscrpt: `방에 대한 설명을 입력해주세요.(최대 ${INPUT.roomDescMaxLen}자)`,
   email: '이메일 (Ex : user@tadaktadak.com)',
   nickname: `닉네임 (최소 2자, 최대 ${INPUT.nicknameMaxLen}자, 영문/숫자/한글)`,
   password: `비밀번호 (최소 ${INPUT.pwdMinLen}자, 최대 ${INPUT.pwdMaxLen}자, 영문, 숫자 조합 / 특수문자 가능)`,

--- a/client/src/utils/constant.ts
+++ b/client/src/utils/constant.ts
@@ -24,7 +24,7 @@ export const SPEAK = {
 
 export const INPUT = {
   emailMaxLen: 25,
-  nicknameMaxLen: 15,
+  nicknameMaxLen: 11,
   pwdMinLen: 6,
   pwdMaxLen: 20,
   roomTitleMaxLen: 20,

--- a/client/src/utils/styleConstant.ts
+++ b/client/src/utils/styleConstant.ts
@@ -3,7 +3,7 @@ import { TOAST_TIME } from './constant';
 const WINDOW_HEIGHT = window.innerHeight;
 
 export const CHAT = {
-  listHeight: '80vh',
+  listHeight: '84vh',
   inputHeight: '10vh',
   inputWidth: '90%',
   msgWidth: '20rem',

--- a/client/src/utils/utils.test.ts
+++ b/client/src/utils/utils.test.ts
@@ -64,7 +64,7 @@ describe('유효한 닉네임 검증하기', () => {
   });
 
   test('가장 긴 닉네임', () => {
-    const validNickname = '한글영어숫자-_.15자가능.';
+    const validNickname = '한글영어숫자-_.11';
     expect(isNickname(validNickname)).toBeTruthy();
   });
 });

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -6,7 +6,7 @@ export const isEmail = (email: string): boolean => {
 };
 
 export const isNickname = (nickname: string): boolean => {
-  const regExp = /^(?=[a-zA-Z가-힣])[-a-zA-Z가-힣0-9_.]{2,15}$/;
+  const regExp = /^(?=[a-zA-Z가-힣])[-a-zA-Z가-힣0-9_.]{2,11}$/;
   return regExp.test(nickname);
 };
 


### PR DESCRIPTION
이제 호스트가 게스트를 강퇴해도 더이상 소켓이 끊기지 않습니다.
#285 
- 자세한 과정에 대한 글은  
  https://painted-albatross-4c9.notion.site/24ccbe4dac6d4f10a4b699327e254097
  에 있습니다.
- 추가로 방 내에서 새로고침 시 기존의 소켓으로 다시 자동연결됩니다.

- 회원가입 시 이메일 중복 / 닉네임 중복에 따라 다른 메시지를 보여주도록 토스트메시지를 수정했습니다.
- 방 사이드바에서 참가자 리스트와 채팅바의 크기를 조절했습니다.
- 한글 닉네임 최대 길이시 2줄로 나타나는 문제로, 닉네임을 15자에서 11자로 제한했습니다.
- 방 생성시에 설명을 의무적으로 적어야 하도록 변경했습니다.
